### PR TITLE
Adapt epplib to support IETF std 69

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,3 +46,27 @@ See the example below
         print(response_info.res_data[0].ex_date)
 
         client.send(Logout())
+
+When using this library with a registry other than Fred, the XML schema must be changed before importing.
+Fred EPP library is tested with Fred and isn't gauranteed to work with anything else.
+
+.. code-block:: python
+
+    # __init__.py
+
+    NAMESPACE = SimpleNamespace(
+        ...
+        NIC_DOMAIN="urn:ietf:params:xml:ns:domain-1.0",
+        ...
+    )
+
+    SCHEMA_LOCATION = SimpleNamespace(
+        ...
+        NIC_DOMAIN="urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd",
+        ...
+    )
+
+    from epplib import constants
+
+    constants.NAMESPACE = NAMESPACE
+    constants.SCHEMA_LOCATION = SCHEMA_LOCATION

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ See the example below
         client.send(Logout())
 
 When using this library with a registry other than Fred, the XML schema must be changed before importing.
-Fred EPP library is tested with Fred and isn't gauranteed to work with anything else.
+Fred EPP library is tested with Fred and isn't guaranteed to work with anything else.
 
 .. code-block:: python
 

--- a/epplib/commands/__init__.py
+++ b/epplib/commands/__init__.py
@@ -19,36 +19,40 @@
 """Module providing EPP commands."""
 
 from .base import Command, Hello, Login, Logout, Request
-from .check import CheckContact, CheckDomain, CheckKeyset, CheckNsset
-from .create import CreateContact, CreateDomain, CreateKeyset, CreateNsset
-from .delete import DeleteContact, DeleteDomain, DeleteKeyset, DeleteNsset
+from .check import CheckContact, CheckDomain, CheckHost, CheckKeyset, CheckNsset
+from .create import CreateContact, CreateDomain, CreateHost, CreateKeyset, CreateNsset
+from .delete import DeleteContact, DeleteDomain, DeleteHost, DeleteKeyset, DeleteNsset
 from .extensions import (CreditInfoRequest, SendAuthInfoContact, SendAuthInfoDomain, SendAuthInfoKeyset,
                          SendAuthInfoNsset, TestNsset)
-from .info import InfoContact, InfoDomain, InfoKeyset, InfoNsset
+from .info import InfoContact, InfoDomain, InfoHost, InfoKeyset, InfoNsset
 from .list import (ListContacts, ListDomains, ListDomainsByContact, ListDomainsByKeyset, ListDomainsByNsset,
                    ListKeysets, ListKeysetsByContact, ListNssets, ListNssetsByContact, ListNssetsByNs, ListResult)
 from .renew import RenewDomain
 from .transfer import TransferContact, TransferDomain, TransferKeyset, TransferNsset
-from .update import UpdateContact, UpdateDomain, UpdateKeyset, UpdateNsset
+from .update import UpdateContact, UpdateDomain, UpdateHost, UpdateKeyset, UpdateNsset
 
 __all__ = [
     'CheckContact',
     'CheckDomain',
+    'CheckHost',
     'CheckKeyset',
     'CheckNsset',
     'Command',
     'CreateContact',
     'CreateDomain',
+    'CreateHost',
     'CreateKeyset',
     'CreateNsset',
     'CreditInfoRequest',
     'DeleteContact',
     'DeleteDomain',
+    'DeleteHost',
     'DeleteKeyset',
     'DeleteNsset',
     'Hello',
     'InfoContact',
     'InfoDomain',
+    'InfoHost',
     'InfoKeyset',
     'InfoNsset',
     'ListContacts',
@@ -77,6 +81,7 @@ __all__ = [
     'TransferNsset',
     'UpdateContact',
     'UpdateDomain',
+    'UpdateHost',
     'UpdateKeyset',
     'UpdateNsset',
 ]

--- a/epplib/commands/check.py
+++ b/epplib/commands/check.py
@@ -24,7 +24,8 @@ from lxml.etree import Element, QName, SubElement
 
 from epplib.commands.base import Command
 from epplib.constants import NAMESPACE, SCHEMA_LOCATION
-from epplib.responses import CheckContactResult, CheckDomainResult, CheckKeysetResult, CheckNssetResult
+from epplib.responses import (CheckContactResult, CheckDomainResult, CheckHostResult, CheckKeysetResult,
+                              CheckNssetResult)
 
 
 class Check(Command):
@@ -85,6 +86,26 @@ class CheckContact(Check):
             Element with a list of contacts to check.
         """
         return self._get_check_payload(NAMESPACE.NIC_CONTACT, SCHEMA_LOCATION.NIC_CONTACT, 'id', self.ids)
+
+
+@dataclass
+class CheckHost(Check):
+    """EPP Domain Check command.
+
+    Attributes:
+        names: Content of the epp/command/check/check/name elements.
+    """
+
+    response_class = CheckHostResult
+    names: List[str]
+
+    def _get_command_payload(self) -> Element:
+        """Create subelements of the command element specific for CheckHost.
+
+        Returns:
+            Element with a list of hosts to check.
+        """
+        return self._get_check_payload(NAMESPACE.NIC_HOST, SCHEMA_LOCATION.NIC_HOST, 'name', self.names)
 
 
 @dataclass

--- a/epplib/commands/create.py
+++ b/epplib/commands/create.py
@@ -42,6 +42,7 @@ class CreateDomain(Command):
         keyset: Content of the epp/command/create/create/keyset element.
         admins: Content of the epp/command/create/create/admin elements.
         auth_info: Content of the epp/command/create/create/authInfo element.
+                   This is a string with FRED XML schema but AuthInfo object with IETF.
     """
 
     response_class = CreateDomainResult
@@ -96,6 +97,7 @@ class CreateContact(Command):
         voice: Content of command/create/create/voice element.
         fax: Content of command/create/create/fax element.
         auth_info: Content of command/create/create/authInfo element.
+                   This is a string with FRED XML schema but AuthInfo object with IETF.
         disclose: Content of command/create/create/disclose element.
         vat: Content of command/create/create/vat element.
         ident: Content of command/create/create/ident element.

--- a/epplib/commands/create.py
+++ b/epplib/commands/create.py
@@ -18,15 +18,16 @@
 
 """Module providing EPP create commands."""
 from dataclasses import dataclass, field
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from lxml.etree import Element, QName, SubElement
 
 from epplib.commands.base import Command
 from epplib.constants import NAMESPACE, SCHEMA_LOCATION
-from epplib.models import Disclose, Dnskey, Ident, Ns, Period, Unit
+from epplib.models import AuthInfo, Disclose, Dnskey, Ident, Ip, Ns, Period, Unit
 from epplib.models.create import CreatePostalInfo
-from epplib.responses import CreateContactResult, CreateDomainResult, CreateKeysetResult, CreateNssetResult
+from epplib.responses import (CreateContactResult, CreateDomainResult, CreateHostResult, CreateKeysetResult,
+                              CreateNssetResult)
 
 
 @dataclass
@@ -52,7 +53,7 @@ class CreateDomain(Command):
     nsset: Optional[str] = None
     keyset: Optional[str] = None
     admins: Sequence[str] = field(default_factory=list)
-    auth_info: Optional[str] = None
+    auth_info: Optional[Union[str, AuthInfo]] = None
 
     def _get_command_payload(self) -> Element:
         """Create subelements of the command element specific for CreateDomain.
@@ -76,7 +77,10 @@ class CreateDomain(Command):
         for item in self.admins:
             SubElement(domain_create, QName(NAMESPACE.NIC_DOMAIN, 'admin')).text = item
         if self.auth_info is not None:
-            SubElement(domain_create, QName(NAMESPACE.NIC_DOMAIN, 'authInfo')).text = self.auth_info
+            if isinstance(self.auth_info, str):
+                SubElement(domain_create, QName(NAMESPACE.NIC_DOMAIN, 'authInfo')).text = self.auth_info
+            elif isinstance(self.auth_info, AuthInfo):
+                domain_create.append(self.auth_info.get_payload())
 
         return create
 
@@ -105,7 +109,7 @@ class CreateContact(Command):
     email: str
     voice: Optional[str] = None
     fax: Optional[str] = None
-    auth_info: Optional[str] = None
+    auth_info: Optional[Union[str, AuthInfo]] = None
     disclose: Optional[Disclose] = None
     vat: Optional[str] = None
     ident: Optional[Ident] = None
@@ -129,8 +133,11 @@ class CreateContact(Command):
         if self.fax:
             SubElement(contact_create, QName(NAMESPACE.NIC_CONTACT, 'fax')).text = self.fax
         SubElement(contact_create, QName(NAMESPACE.NIC_CONTACT, 'email')).text = self.email
-        if self.auth_info:
-            SubElement(contact_create, QName(NAMESPACE.NIC_CONTACT, 'authInfo')).text = self.auth_info
+        if self.auth_info is not None:
+            if isinstance(self.auth_info, str):
+                SubElement(contact_create, QName(NAMESPACE.NIC_CONTACT, 'authInfo')).text = self.auth_info
+            elif isinstance(self.auth_info, AuthInfo):
+                contact_create.append(self.auth_info.get_payload())
         if self.disclose:
             contact_create.append(self.disclose.get_payload())
         if self.vat:
@@ -139,6 +146,38 @@ class CreateContact(Command):
             contact_create.append(self.ident.get_payload())
         if self.notify_email:
             SubElement(contact_create, QName(NAMESPACE.NIC_CONTACT, 'notifyEmail')).text = self.notify_email
+
+        return create
+
+
+@dataclass
+class CreateHost(Command):
+    """EPP Create Host command.
+
+    Attributes:
+        name: Content of command/create/create/name element.
+        addrs: Content of command/create/create/addr element.
+    """
+
+    response_class = CreateHostResult
+
+    name: str
+    addrs: Optional[Sequence[Ip]] = field(default_factory=list)
+
+    def _get_command_payload(self) -> Element:
+        """Create subelements of the command element specific for CreateHost.
+
+        Returns:
+            Element with a host to create.
+        """
+        create = Element(QName(NAMESPACE.EPP, 'create'))
+
+        host_create = SubElement(create, QName(NAMESPACE.NIC_HOST, 'create'))
+        host_create.set(QName(NAMESPACE.XSI, 'schemaLocation'), SCHEMA_LOCATION.NIC_HOST)
+
+        SubElement(host_create, QName(NAMESPACE.NIC_HOST, 'name')).text = self.name
+        for addr in self.addrs:
+            host_create.append(addr.get_payload())
 
         return create
 

--- a/epplib/commands/delete.py
+++ b/epplib/commands/delete.py
@@ -85,6 +85,25 @@ class DeleteContact(Delete):
 
 
 @dataclass
+class DeleteHost(Delete):
+    """EPP Host Delete command.
+
+    Attributes:
+        name: Content of the epp/command/delete/delete/name element.
+    """
+
+    name: str
+
+    def _get_command_payload(self) -> Element:
+        """Create subelements of the command element specific for DeleteHost.
+
+        Returns:
+            Element with a list of domains to delete.
+        """
+        return self._get_delete_payload(NAMESPACE.NIC_HOST, SCHEMA_LOCATION.NIC_HOST, 'name', self.name)
+
+
+@dataclass
 class DeleteKeyset(Delete):
     """EPP Delete keyset command.
 

--- a/epplib/commands/transfer.py
+++ b/epplib/commands/transfer.py
@@ -18,11 +18,13 @@
 
 """Module providing EPP transfer commands."""
 from dataclasses import dataclass
+from typing import Union
 
 from lxml.etree import Element, QName, SubElement
 
 from epplib.commands.base import Command
 from epplib.constants import NAMESPACE, SCHEMA_LOCATION
+from epplib.models import AuthInfo
 from epplib.responses import Result
 
 
@@ -43,7 +45,10 @@ class Transfer(Command):
         item_transfer = SubElement(root, QName(namespace, 'transfer'))
         item_transfer.set(QName(NAMESPACE.XSI, 'schemaLocation'), schema_location)
         SubElement(item_transfer, QName(namespace, tag)).text = item
-        SubElement(item_transfer, QName(namespace, 'authInfo')).text = self.auth_info
+        if isinstance(self.auth_info, str):
+            SubElement(item_transfer, QName(namespace, 'authInfo')).text = self.auth_info
+        elif isinstance(self.auth_info, AuthInfo):
+            item_transfer.append(self.auth_info.get_payload())
 
         return root
 
@@ -58,7 +63,7 @@ class TransferDomain(Transfer):
     """
 
     name: str
-    auth_info: str
+    auth_info: Union[str, AuthInfo]
 
     def _get_command_payload(self) -> Element:
         """Create subelements of the command element specific for TransferDomain.
@@ -79,7 +84,7 @@ class TransferContact(Transfer):
     """
 
     id: str
-    auth_info: str
+    auth_info: Union[str, AuthInfo]
 
     def _get_command_payload(self) -> Element:
         """Create subelements of the command element specific for TransferContact.

--- a/epplib/commands/update.py
+++ b/epplib/commands/update.py
@@ -41,6 +41,7 @@ class UpdateDomain(Command):
         keyset: Content of epp/command/update/update/chg/keyset
         registrant: Content of epp/command/update/update/chg/registrant
         auth_info: Content of epp/command/update/update/chg/authInfo
+                   This is a string with FRED XML schema but AuthInfo object with IETF.
     """
 
     response_class = Result
@@ -111,6 +112,7 @@ class UpdateContact(Command):
         fax: Content of epp/command/update/update/chg/fax element.
         email: Content of epp/command/update/update/chg/email element.
         auth_info: Content of epp/command/update/update/chg/authInfo element.
+                   This is a string with FRED XML schema but AuthInfo object with IETF.
         disclose: Content of epp/command/update/update/chg/disclose element.
         vat: Content of epp/command/update/update/chg/vat element.
         ident: Content of epp/command/update/update/chg/ident element.

--- a/epplib/constants.py
+++ b/epplib/constants.py
@@ -28,6 +28,7 @@ NAMESPACE = SimpleNamespace(
     NIC_DOMAIN='http://www.nic.cz/xml/epp/domain-1.4',
     NIC_ENUMVAL='http://www.nic.cz/xml/epp/enumval-1.2',
     NIC_EXTRA_ADDR='http://www.nic.cz/xml/epp/extra-addr-1.0',
+    NIC_HOST='urn:ietf:params:xml:ns:host-1.0',
     NIC_KEYSET='http://www.nic.cz/xml/epp/keyset-1.3',
     NIC_NSSET='http://www.nic.cz/xml/epp/nsset-1.2',
 )
@@ -38,6 +39,7 @@ SCHEMA_LOCATION = SimpleNamespace(
     NIC_DOMAIN='http://www.nic.cz/xml/epp/domain-1.4 domain-1.4.2.xsd',
     NIC_ENUMVAL='http://www.nic.cz/xml/epp/enumval-1.2 enumval-1.2.0.xsd',
     NIC_EXTRA_ADDR='http://www.nic.cz/xml/epp/extra-addr-1.0 extra-addr-1.0.0.xsd',
+    NIC_HOST='urn:ietf:params:xml:ns:host-1.0 host-1.0.xsd',
     NIC_KEYSET='http://www.nic.cz/xml/epp/keyset-1.3 keyset-1.3.2.xsd',
     NIC_NSSET='http://www.nic.cz/xml/epp/nsset-1.2 nsset-1.2.2.xsd',
 )

--- a/epplib/models/__init__.py
+++ b/epplib/models/__init__.py
@@ -18,19 +18,28 @@
 
 """Module providing data models for EPP commands and responses."""
 
-from .common import (Addr, ContactAddr, Disclose, DiscloseField, Dnskey, ExtraAddr, ExtractModelMixin, Ident, IdentType,
-                     Ns, PayloadModelMixin, Period, PostalInfo, Statement, Status, TestResult, Unit)
+from .common import (Addr, AuthInfo, ContactAddr, ContactAuthInfo, Disclose, DiscloseField, Dnskey,
+                     DomainAuthInfo, DomainContact, ExtraAddr, ExtractModelMixin, HostObjSet, HostStatus, Ident,
+                     IdentType, Ip, Ns, PayloadModelMixin, Period, PostalInfo, Statement, Status, TestResult, Unit)
+
 
 __all__ = [
     'Addr',
+    'AuthInfo',
     'ContactAddr',
+    'ContactAuthInfo',
     'Disclose',
     'DiscloseField',
     'Dnskey',
+    'DomainAuthInfo',
+    'DomainContact',
     'ExtraAddr',
     'ExtractModelMixin',
+    'HostObjSet',
+    'HostStatus',
     'Ident',
     'IdentType',
+    'Ip',
     'Ns',
     'PayloadModelMixin',
     'Period',

--- a/epplib/models/check.py
+++ b/epplib/models/check.py
@@ -77,6 +77,31 @@ class CheckContactResultData(ExtractModelMixin):
 
 
 @dataclass
+class CheckHostResultData(ExtractModelMixin):
+    """Dataclass representing host availability in the check host result.
+
+    Attributes:
+        name: Content of the epp/response/resData/chkData/cd/name element.
+        avail: Avail attribute of the epp/response/resData/chkData/cd/name element.
+        reason: Content of the epp/response/resData/chkData/cd/reason element.
+    """
+
+    name: str
+    avail: Optional[bool]
+    reason: Optional[str] = None
+
+    @classmethod
+    def extract(cls, element: Element) -> 'CheckHostResultData':
+        """Extract params for own init from the element."""
+        params = (
+            cls._find_text(element, './host:name'),
+            cls._str_to_bool(cls._find_attrib(element, './host:name', 'avail')),
+            cls._find_text(element, './host:reason'),
+        )
+        return cls(*params)
+
+
+@dataclass
 class CheckNssetResultData(ExtractModelMixin):
     """Dataclass representing nsset availability in the check nsset result.
 

--- a/epplib/models/create.py
+++ b/epplib/models/create.py
@@ -63,6 +63,30 @@ class CreateDomainResultData(ExtractModelMixin):
 
 
 @dataclass
+class CreateHostResultData(ExtractModelMixin):
+    """Dataclass representing result of host creation.
+
+    Attributes:
+        name: Content of the epp/response/resData/creData/name element.
+        cr_date: Content of the epp/response/resData/creData/crDate element.
+    """
+
+    name: str
+    cr_date: datetime
+
+    _namespace_prefix: ClassVar[Optional[str]] = 'host'
+
+    @classmethod
+    def extract(cls, element: Element) -> 'CreateHostResultData':
+        """Extract params for own init from the element."""
+        params = (
+            cls._find_text(element, './{}:name'.format(cls._namespace_prefix)),
+            parse_datetime(cls._find_text(element, './{}:crDate'.format(cls._namespace_prefix))),
+        )
+        return cls(*params)
+
+
+@dataclass
 class CreateNonDomainResultData(ExtractModelMixin):
     """Dataclass representing result of creation of object other than domain.
 

--- a/epplib/responses/__init__.py
+++ b/epplib/responses/__init__.py
@@ -19,20 +19,22 @@
 """Module providing means to process responses to EPP commands."""
 
 from .base import Greeting, ParsingError, Response, Result
-from .check import CheckContactResult, CheckDomainResult, CheckKeysetResult, CheckNssetResult
-from .create import CreateContactResult, CreateDomainResult, CreateKeysetResult, CreateNssetResult
+from .check import CheckContactResult, CheckDomainResult, CheckHostResult, CheckKeysetResult, CheckNssetResult
+from .create import CreateContactResult, CreateDomainResult, CreateHostResult, CreateKeysetResult, CreateNssetResult
 from .credit_info import CreditInfoResult
-from .info import InfoContactResult, InfoDomainResult, InfoKeysetResult, InfoNssetResult
+from .info import InfoContactResult, InfoDomainResult, InfoHostResult, InfoKeysetResult, InfoNssetResult
 from .list import GetResultsResult, ListResult
 from .renew import RenewDomainResult
 
 __all__ = [
     'CheckContactResult',
     'CheckDomainResult',
+    'CheckHostResult',
     'CheckKeysetResult',
     'CheckNssetResult',
     'CreateContactResult',
     'CreateDomainResult',
+    'CreateHostResult',
     'CreateKeysetResult',
     'CreateNssetResult',
     'CreditInfoResult',
@@ -40,6 +42,7 @@ __all__ = [
     'Greeting',
     'InfoContactResult',
     'InfoDomainResult',
+    'InfoHostResult',
     'InfoKeysetResult',
     'InfoNssetResult',
     'ListResult',

--- a/epplib/responses/check.py
+++ b/epplib/responses/check.py
@@ -20,8 +20,8 @@
 
 from dataclasses import dataclass
 
-from epplib.models.check import (CheckContactResultData, CheckDomainResultData, CheckKeysetResultData,
-                                 CheckNssetResultData)
+from epplib.models.check import (CheckContactResultData, CheckDomainResultData, CheckHostResultData,
+                                 CheckKeysetResultData, CheckNssetResultData)
 from epplib.responses.base import Result
 
 
@@ -55,6 +55,22 @@ class CheckContactResult(Result[CheckContactResultData]):
 
     _res_data_path = './contact:chkData/contact:cd'
     _res_data_class = CheckContactResultData
+
+
+@dataclass
+class CheckHostResult(Result[CheckHostResultData]):
+    """Represents EPP Result which responds to the Check host command.
+
+    Attributes:
+        code: Code attribute of the epp/response/result element.
+        msg: Content of the epp/response/result/msg element.
+        res_data: Content of the epp/response/result/resData element.
+        cl_tr_id: Content of the epp/response/trID/clTRID element.
+        sv_tr_id: Content of the epp/response/trID/svTRID element.
+    """
+
+    _res_data_path = './host:chkData/host:cd'
+    _res_data_class = CheckHostResultData
 
 
 @dataclass

--- a/epplib/responses/create.py
+++ b/epplib/responses/create.py
@@ -21,8 +21,8 @@
 from dataclasses import dataclass
 from typing import ClassVar, Optional
 
-from epplib.models.create import (CreateContactResultData, CreateDomainResultData, CreateKeysetResultData,
-                                  CreateNssetResultData)
+from epplib.models.create import (CreateContactResultData, CreateDomainResultData, CreateHostResultData,
+                                  CreateKeysetResultData, CreateNssetResultData)
 from epplib.responses.base import Result, T
 
 
@@ -73,6 +73,23 @@ class CreateContactResult(CreateNonDomainResult[CreateContactResultData]):
     _namespace_prefix: ClassVar[Optional[str]] = 'contact'
     _res_data_path = './{}:creData'.format(_namespace_prefix)
     _res_data_class = CreateContactResultData
+
+
+@dataclass
+class CreateHostResult(CreateNonDomainResult[CreateHostResultData]):
+    """Represents EPP Result which responds to the create host command.
+
+    Attributes:
+        code: Code attribute of the epp/response/result element.
+        msg: Content of the epp/response/result/msg element.
+        res_data: Content of the epp/response/result/resData element.
+        cl_tr_id: Content of the epp/response/trID/clTRID element.
+        sv_tr_id: Content of the epp/response/trID/svTRID element.
+    """
+
+    _namespace_prefix: ClassVar[Optional[str]] = 'host'
+    _res_data_path = './{}:creData'.format(_namespace_prefix)
+    _res_data_class = CreateHostResultData
 
 
 @dataclass

--- a/epplib/responses/info.py
+++ b/epplib/responses/info.py
@@ -20,7 +20,8 @@
 
 from dataclasses import dataclass
 
-from epplib.models.info import InfoContactResultData, InfoDomainResultData, InfoKeysetResultData, InfoNssetResultData
+from epplib.models.info import (InfoContactResultData, InfoDomainResultData, InfoHostResultData, InfoKeysetResultData,
+                                InfoNssetResultData)
 from epplib.responses.base import Result
 
 
@@ -54,6 +55,22 @@ class InfoContactResult(Result[InfoContactResultData]):
 
     _res_data_path = './contact:infData'
     _res_data_class = InfoContactResultData
+
+
+@dataclass
+class InfoHostResult(Result[InfoHostResultData]):
+    """Represents EPP Result which responds to the Info host command.
+
+    Attributes:
+        code: Code attribute of the epp/response/result element.
+        message: Content of the epp/response/result/msg element.
+        data: Content of the epp/response/result/resData element.
+        cl_tr_id: Content of the epp/response/trID/clTRID element.
+        sv_tr_id: Content of the epp/response/trID/svTRID element.
+    """
+
+    _res_data_path = './host:infData'
+    _res_data_class = InfoHostResultData
 
 
 @dataclass

--- a/epplib/responses/poll_messages.py
+++ b/epplib/responses/poll_messages.py
@@ -28,8 +28,8 @@ from lxml.etree import Element, QName
 
 from epplib.constants import NAMESPACE
 from epplib.models import TestResult
-from epplib.models.info import (InfoContactResultData, InfoDomainResultData, InfoKeysetResultData, InfoNssetResultData,
-                                InfoResultData)
+from epplib.models.info import (InfoContactResultData, InfoDomainResultData, InfoHostResultData, InfoKeysetResultData,
+                                InfoNssetResultData, InfoResultData)
 from epplib.utils import ParseXMLMixin
 
 T = TypeVar('T', bound=InfoResultData)
@@ -376,6 +376,16 @@ class ContactUpdate(ObjectUpdate[InfoContactResultData]):
     _inf_data_cls = InfoContactResultData
 
     tag = QName(NAMESPACE.NIC_CONTACT, 'updateData')
+
+
+@dataclass
+class HostUpdate(ObjectUpdate[InfoHostResultData]):
+    """Host update poll message."""
+
+    _prefix = 'host'
+    _inf_data_cls = InfoHostResultData
+
+    tag = QName(NAMESPACE.NIC_HOST, 'updateData')
 
 
 @dataclass

--- a/epplib/tests/tests_ietf/__init__.py
+++ b/epplib/tests/tests_ietf/__init__.py
@@ -1,4 +1,0 @@
-# from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION
-# import epplib.constants 
-# epplib.constants.NAMESPACE = NAMESPACE
-# epplib.constants.SCHEMA_LOCATION = SCHEMA_LOCATION

--- a/epplib/tests/tests_ietf/__init__.py
+++ b/epplib/tests/tests_ietf/__init__.py
@@ -1,0 +1,4 @@
+# from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION
+# import epplib.constants 
+# epplib.constants.NAMESPACE = NAMESPACE
+# epplib.constants.SCHEMA_LOCATION = SCHEMA_LOCATION

--- a/epplib/tests/tests_ietf/constants.py
+++ b/epplib/tests/tests_ietf/constants.py
@@ -1,0 +1,31 @@
+from lxml.etree import XMLSchema
+from pathlib import Path
+from types import SimpleNamespace
+
+NAMESPACE = SimpleNamespace(
+    EPP='urn:ietf:params:xml:ns:epp-1.0',
+    XSI='http://www.w3.org/2001/XMLSchema-instance',
+    FRED='noop',
+    NIC_CONTACT='urn:ietf:params:xml:ns:contact-1.0',
+    NIC_DOMAIN='urn:ietf:params:xml:ns:domain-1.0',
+    NIC_ENUMVAL='noop',
+    NIC_EXTRA_ADDR='noop',
+    NIC_HOST='urn:ietf:params:xml:ns:host-1.0',
+    NIC_KEYSET='noop',
+    NIC_NSSET='noop',
+)
+
+SCHEMA_LOCATION = SimpleNamespace(
+    XSI='urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd',
+    FRED='noop fred-1.5.0.xsd',
+    NIC_CONTACT='urn:ietf:params:xml:ns:contact-1.0 contact-1.0.xsd',
+    NIC_DOMAIN='urn:ietf:params:xml:ns:domain-1.0 domain-1.0.xsd',
+    NIC_ENUMVAL='noop enumval-1.2.0.xsd',
+    NIC_EXTRA_ADDR='noop extra-addr-1.0.0.xsd',
+    NIC_HOST='urn:ietf:params:xml:ns:host-1.0 host-1.0.xsd',
+    NIC_KEYSET='noop keyset-1.3.2.xsd',
+    NIC_NSSET='noop nsset-1.2.2.xsd',
+)
+
+BASE_DATA_PATH = Path(__file__).parent / 'data'
+SCHEMA = XMLSchema(file=str(BASE_DATA_PATH / 'schemas/all-1.0.xsd'))

--- a/epplib/tests/tests_ietf/data/schemas/all-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/all-1.0.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+  <!--
+  This schema does not define anything, it just imports other schemas
+  and makes the usage of EPP schemas more convenient.
+  -->
+  <schema targetNamespace="urn:ietf:params:xml:ns:all-1.0"
+          xmlns:all="urn:ietf:params:xml:ns:all-1.0"
+          xmlns="http://www.w3.org/2001/XMLSchema"
+          elementFormDefault="qualified">
+
+    <!--
+    Import all schemas related to EPP protocol.
+    Anytime the version of any imported schema is raised, the version of
+    'all' schema must be raised too.
+
+    eppcom and epp schemas never change the version. This would result
+    in incompatibility with EPP standard.
+    -->
+    <import namespace="urn:ietf:params:xml:ns:eppcom-1.0"
+      schemaLocation="eppcom-1.0.xsd"/>
+    <import namespace="urn:ietf:params:xml:ns:epp-1.0"
+      schemaLocation="epp-1.0.xsd"/>
+    <import namespace="urn:ietf:params:xml:ns:contact-1.0"
+      schemaLocation="contact-1.0.xsd"/>
+    <import namespace="urn:ietf:params:xml:ns:host-1.0"
+      schemaLocation="host-1.0.xsd"/>
+    <import namespace="urn:ietf:params:xml:ns:domain-1.0"
+      schemaLocation="domain-1.0.xsd"/>
+
+    <annotation>
+      <documentation>
+        Extensible Provisioning Protocol v1.0
+        all schema's grouped together
+      </documentation>
+    </annotation>
+
+  </schema>

--- a/epplib/tests/tests_ietf/data/schemas/contact-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/contact-1.0.xsd
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<schema targetNamespace="urn:ietf:params:xml:ns:contact-1.0"
+  xmlns:contact="urn:ietf:params:xml:ns:contact-1.0"
+  xmlns:epp="urn:ietf:params:xml:ns:epp-1.0"
+  xmlns:eppcom="urn:ietf:params:xml:ns:eppcom-1.0"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+
+  <!--
+Import common element types.
+-->
+  <import namespace="urn:ietf:params:xml:ns:eppcom-1.0" />
+  <import namespace="urn:ietf:params:xml:ns:epp-1.0" />
+
+  <annotation>
+    <documentation> Extensible Provisioning Protocol v1.0 contact provisioning schema. </documentation>
+  </annotation>
+
+  <!--
+Child elements found in EPP commands.
+-->
+  <element name="check" type="contact:mIDType" />
+  <element name="create" type="contact:createType" />
+  <element name="delete" type="contact:sIDType" />
+  <element name="info" type="contact:authIDType" />
+  <element name="transfer" type="contact:authIDType" />
+  <element name="update" type="contact:updateType" />
+
+  <!--
+Utility types.
+-->
+  <simpleType name="ccType">
+    <restriction base="token">
+      <length value="2" />
+    </restriction>
+  </simpleType>
+  <complexType name="e164Type">
+    <simpleContent>
+      <extension base="contact:e164StringType">
+        <attribute name="x" type="token" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="e164StringType">
+    <restriction base="token">
+      <pattern value="(\+[0-9]{1,3}\.[0-9]{1,14})?" />
+      <maxLength value="17" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="pcType">
+    <restriction base="token">
+      <maxLength value="16" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="postalLineType">
+    <restriction base="normalizedString">
+      <minLength value="1" />
+      <maxLength value="255" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="optPostalLineType">
+    <restriction base="normalizedString">
+      <maxLength value="255" />
+    </restriction>
+  </simpleType>
+
+  <!--
+Child elements of the <create> command.
+-->
+  <complexType name="createType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="postalInfo" type="contact:postalInfoType"
+        maxOccurs="2" />
+      <element name="voice" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="fax" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="email" type="eppcom:minTokenType" />
+      <element name="authInfo" type="contact:authInfoType" />
+      <element name="disclose" type="contact:discloseType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <complexType name="postalInfoType">
+    <sequence>
+      <element name="name" type="contact:postalLineType" />
+      <element name="org" type="contact:optPostalLineType"
+        minOccurs="0" />
+      <element name="addr" type="contact:addrType" />
+    </sequence>
+    <attribute name="type" type="contact:postalInfoEnumType"
+      use="required" />
+  </complexType>
+
+  <simpleType name="postalInfoEnumType">
+    <restriction base="token">
+      <enumeration value="loc" />
+      <enumeration value="int" />
+    </restriction>
+  </simpleType>
+
+  <complexType name="addrType">
+    <sequence>
+      <element name="street" type="contact:optPostalLineType"
+        minOccurs="0" maxOccurs="3" />
+      <element name="city" type="contact:postalLineType" />
+      <element name="sp" type="contact:optPostalLineType"
+        minOccurs="0" />
+      <element name="pc" type="contact:pcType"
+        minOccurs="0" />
+      <element name="cc" type="contact:ccType" />
+    </sequence>
+  </complexType>
+
+  <complexType name="authInfoType">
+    <choice>
+      <element name="pw" type="eppcom:pwAuthInfoType" />
+      <element name="ext" type="eppcom:extAuthInfoType" />
+    </choice>
+  </complexType>
+
+  <complexType name="discloseType">
+    <sequence>
+      <element name="name" type="contact:intLocType"
+        minOccurs="0" maxOccurs="2" />
+      <element name="org" type="contact:intLocType"
+        minOccurs="0" maxOccurs="2" />
+      <element name="addr" type="contact:intLocType"
+        minOccurs="0" maxOccurs="2" />
+      <element name="voice" minOccurs="0" />
+      <element name="fax" minOccurs="0" />
+      <element name="email" minOccurs="0" />
+    </sequence>
+    <attribute name="flag" type="boolean" use="required" />
+  </complexType>
+
+  <complexType name="intLocType">
+    <attribute name="type" type="contact:postalInfoEnumType"
+      use="required" />
+  </complexType>
+
+  <!--
+Child element of commands that require only an identifier.
+-->
+  <complexType name="sIDType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child element of commands that accept multiple identifiers.
+-->
+  <complexType name="mIDType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType"
+        maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child elements of the <info> and <transfer> commands.
+-->
+  <complexType name="authIDType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="authInfo" type="contact:authInfoType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child elements of the <update> command.
+-->
+  <complexType name="updateType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="add" type="contact:addRemType"
+        minOccurs="0" />
+      <element name="rem" type="contact:addRemType"
+        minOccurs="0" />
+      <element name="chg" type="contact:chgType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Data elements that can be added or removed.
+-->
+  <complexType name="addRemType">
+    <sequence>
+      <element name="status" type="contact:statusType"
+        maxOccurs="7" />
+    </sequence>
+  </complexType>
+
+  <!--
+Data elements that can be changed.
+-->
+  <complexType name="chgType">
+    <sequence>
+      <element name="postalInfo" type="contact:chgPostalInfoType"
+        minOccurs="0" maxOccurs="2" />
+      <element name="voice" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="fax" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="email" type="eppcom:minTokenType"
+        minOccurs="0" />
+      <element name="authInfo" type="contact:authInfoType"
+        minOccurs="0" />
+      <element name="disclose" type="contact:discloseType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <complexType name="chgPostalInfoType">
+    <sequence>
+      <element name="name" type="contact:postalLineType"
+        minOccurs="0" />
+      <element name="org" type="contact:optPostalLineType"
+        minOccurs="0" />
+      <element name="addr" type="contact:addrType"
+        minOccurs="0" />
+    </sequence>
+    <attribute name="type" type="contact:postalInfoEnumType"
+      use="required" />
+  </complexType>
+
+  <!--
+Child response elements.
+-->
+  <element name="chkData" type="contact:chkDataType" />
+  <element name="creData" type="contact:creDataType" />
+  <element name="infData" type="contact:infDataType" />
+  <element name="panData" type="contact:panDataType" />
+  <element name="trnData" type="contact:trnDataType" />
+
+  <!--
+<check> response elements.
+-->
+  <complexType name="chkDataType">
+    <sequence>
+      <element name="cd" type="contact:checkType"
+        maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+
+  <complexType name="checkType">
+    <sequence>
+      <element name="id" type="contact:checkIDType" />
+      <element name="reason" type="eppcom:reasonType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <complexType name="checkIDType">
+    <simpleContent>
+      <extension base="eppcom:clIDType">
+        <attribute name="avail" type="boolean"
+          use="required" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <!--
+<create> response elements.
+-->
+  <complexType name="creDataType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="crDate" type="dateTime" />
+    </sequence>
+  </complexType>
+
+  <!--
+<info> response elements.
+-->
+  <complexType name="infDataType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="roid" type="eppcom:roidType" />
+      <element name="status" type="contact:statusType"
+        maxOccurs="7" />
+      <element name="postalInfo" type="contact:postalInfoType"
+        maxOccurs="2" />
+      <element name="voice" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="fax" type="contact:e164Type"
+        minOccurs="0" />
+      <element name="email" type="eppcom:minTokenType" />
+      <element name="clID" type="eppcom:clIDType" />
+      <element name="crID" type="eppcom:clIDType" />
+      <element name="crDate" type="dateTime" />
+      <element name="upID" type="eppcom:clIDType"
+        minOccurs="0" />
+      <element name="upDate" type="dateTime"
+        minOccurs="0" />
+      <element name="trDate" type="dateTime"
+        minOccurs="0" />
+      <element name="authInfo" type="contact:authInfoType"
+        minOccurs="0" />
+      <element name="disclose" type="contact:discloseType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Status is a combination of attributes and an optional human-readable
+message that may be expressed in languages other than English.
+-->
+  <complexType name="statusType">
+    <simpleContent>
+      <extension base="normalizedString">
+        <attribute name="s" type="contact:statusValueType"
+          use="required" />
+        <attribute name="lang" type="language"
+          default="en" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="statusValueType">
+    <restriction base="token">
+      <enumeration value="clientDeleteProhibited" />
+      <enumeration value="clientTransferProhibited" />
+      <enumeration value="clientUpdateProhibited" />
+      <enumeration value="linked" />
+      <enumeration value="ok" />
+      <enumeration value="pendingCreate" />
+      <enumeration value="pendingDelete" />
+      <enumeration value="pendingTransfer" />
+      <enumeration value="pendingUpdate" />
+      <enumeration value="serverDeleteProhibited" />
+      <enumeration value="serverTransferProhibited" />
+      <enumeration value="serverUpdateProhibited" />
+    </restriction>
+  </simpleType>
+
+  <!--
+Pending action notification response elements.
+-->
+  <complexType name="panDataType">
+    <sequence>
+      <element name="id" type="contact:paCLIDType" />
+      <element name="paTRID" type="epp:trIDType" />
+      <element name="paDate" type="dateTime" />
+    </sequence>
+  </complexType>
+
+  <complexType name="paCLIDType">
+    <simpleContent>
+      <extension base="eppcom:clIDType">
+        <attribute name="paResult" type="boolean"
+          use="required" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <!--
+<transfer> response elements.
+-->
+  <complexType name="trnDataType">
+    <sequence>
+      <element name="id" type="eppcom:clIDType" />
+      <element name="trStatus" type="eppcom:trStatusType" />
+      <element name="reID" type="eppcom:clIDType" />
+      <element name="reDate" type="dateTime" />
+      <element name="acID" type="eppcom:clIDType" />
+      <element name="acDate" type="dateTime" />
+    </sequence>
+  </complexType>
+
+  <!--
+End of schema.
+-->
+</schema>

--- a/epplib/tests/tests_ietf/data/schemas/domain-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/domain-1.0.xsd
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<schema targetNamespace="urn:ietf:params:xml:ns:domain-1.0"
+  xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"
+  xmlns:host="urn:ietf:params:xml:ns:host-1.0"
+  xmlns:epp="urn:ietf:params:xml:ns:epp-1.0"
+  xmlns:eppcom="urn:ietf:params:xml:ns:eppcom-1.0"
+  xmlns="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+
+  <!--
+Import common element types.
+-->
+  <import namespace="urn:ietf:params:xml:ns:eppcom-1.0" />
+  <import namespace="urn:ietf:params:xml:ns:epp-1.0" />
+  <import namespace="urn:ietf:params:xml:ns:host-1.0" />
+
+  <annotation>
+    <documentation> Extensible Provisioning Protocol v1.0 domain provisioning schema. </documentation>
+  </annotation>
+
+  <!--
+Child elements found in EPP commands.
+-->
+  <element name="check" type="domain:mNameType" />
+  <element name="create" type="domain:createType" />
+  <element name="delete" type="domain:sNameType" />
+  <element name="info" type="domain:infoType" />
+  <element name="renew" type="domain:renewType" />
+  <element name="transfer" type="domain:transferType" />
+  <element name="update" type="domain:updateType" />
+  <!--
+Child elements of the <create> command.
+-->
+  <complexType name="createType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="period" type="domain:periodType"
+        minOccurs="0" />
+      <element name="ns" type="domain:nsType"
+        minOccurs="0" />
+      <element name="registrant" type="eppcom:clIDType"
+        minOccurs="0" />
+      <element name="contact" type="domain:contactType"
+        minOccurs="0" maxOccurs="unbounded" />
+      <element name="authInfo" type="domain:authInfoType" />
+    </sequence>
+  </complexType>
+
+  <complexType name="periodType">
+    <simpleContent>
+      <extension base="domain:pLimitType">
+        <attribute name="unit" type="domain:pUnitType"
+          use="required" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="pLimitType">
+    <restriction base="unsignedShort">
+      <minInclusive value="1" />
+      <maxInclusive value="99" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="pUnitType">
+    <restriction base="token">
+      <enumeration value="y" />
+      <enumeration value="m" />
+    </restriction>
+  </simpleType>
+
+  <complexType name="nsType">
+    <choice>
+      <element name="hostObj" type="eppcom:labelType"
+        maxOccurs="unbounded" />
+      <element name="hostAttr" type="domain:hostAttrType"
+        maxOccurs="unbounded" />
+    </choice>
+  </complexType>
+  <!--
+Name servers are either host objects or attributes.
+-->
+
+  <complexType name="hostAttrType">
+    <sequence>
+      <element name="hostName" type="eppcom:labelType" />
+      <element name="hostAddr" type="host:addrType"
+        minOccurs="0" maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+  <!--
+If attributes, addresses are optional and follow the
+structure defined in the host mapping.
+-->
+
+  <complexType name="contactType">
+    <simpleContent>
+      <extension base="eppcom:clIDType">
+        <attribute name="type" type="domain:contactAttrType" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="contactAttrType">
+    <restriction base="token">
+      <enumeration value="admin" />
+      <enumeration value="billing" />
+      <enumeration value="tech" />
+    </restriction>
+  </simpleType>
+
+  <complexType name="authInfoType">
+    <choice>
+      <element name="pw" type="eppcom:pwAuthInfoType" />
+      <element name="ext" type="eppcom:extAuthInfoType" />
+    </choice>
+  </complexType>
+
+  <!--
+Child element of commands that require a single name.
+-->
+  <complexType name="sNameType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+    </sequence>
+  </complexType>
+  <!--
+Child element of commands that accept multiple names.
+-->
+  <complexType name="mNameType">
+    <sequence>
+      <element name="name" type="eppcom:labelType"
+        maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child elements of the <info> command.
+-->
+  <complexType name="infoType">
+    <sequence>
+      <element name="name" type="domain:infoNameType" />
+      <element name="authInfo" type="domain:authInfoType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <complexType name="infoNameType">
+    <simpleContent>
+      <extension base="eppcom:labelType">
+        <attribute name="hosts" type="domain:hostsType"
+          default="all" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="hostsType">
+    <restriction base="token">
+      <enumeration value="all" />
+      <enumeration value="del" />
+      <enumeration value="none" />
+      <enumeration value="sub" />
+    </restriction>
+  </simpleType>
+
+  <!--
+Child elements of the <renew> command.
+-->
+  <complexType name="renewType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="curExpDate" type="date" />
+      <element name="period" type="domain:periodType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child elements of the <transfer> command.
+-->
+  <complexType name="transferType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="period" type="domain:periodType"
+        minOccurs="0" />
+      <element name="authInfo" type="domain:authInfoType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Child elements of the <update> command.
+-->
+  <complexType name="updateType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="add" type="domain:addRemType"
+        minOccurs="0" />
+      <element name="rem" type="domain:addRemType"
+        minOccurs="0" />
+      <element name="chg" type="domain:chgType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Data elements that can be added or removed.
+-->
+  <complexType name="addRemType">
+    <sequence>
+      <element name="ns" type="domain:nsType"
+        minOccurs="0" />
+      <element name="contact" type="domain:contactType"
+        minOccurs="0" maxOccurs="unbounded" />
+      <element name="status" type="domain:statusType"
+        minOccurs="0" maxOccurs="11" />
+    </sequence>
+  </complexType>
+
+  <!--
+Data elements that can be changed.
+-->
+  <complexType name="chgType">
+    <sequence>
+      <element name="registrant" type="domain:clIDChgType"
+        minOccurs="0" />
+      <element name="authInfo" type="domain:authInfoChgType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Allow the registrant value to be nullified by changing the
+minLength restriction to "0".
+-->
+  <simpleType name="clIDChgType">
+    <restriction base="token">
+      <minLength value="0" />
+      <maxLength value="16" />
+    </restriction>
+  </simpleType>
+
+  <!--
+Allow the authInfo value to be nullified by including an
+empty element within the choice.
+-->
+  <complexType name="authInfoChgType">
+    <choice>
+      <element name="pw" type="eppcom:pwAuthInfoType" />
+      <element name="ext" type="eppcom:extAuthInfoType" />
+      <element name="null" />
+    </choice>
+  </complexType>
+
+  <!--
+Child response elements.
+-->
+  <element name="chkData" type="domain:chkDataType" />
+  <element name="creData" type="domain:creDataType" />
+  <element name="infData" type="domain:infDataType" />
+  <element name="panData" type="domain:panDataType" />
+  <element name="renData" type="domain:renDataType" />
+  <element name="trnData" type="domain:trnDataType" />
+
+  <!--
+<check> response elements.
+-->
+  <complexType name="chkDataType">
+    <sequence>
+      <element name="cd" type="domain:checkType"
+        maxOccurs="unbounded" />
+    </sequence>
+  </complexType>
+
+  <complexType name="checkType">
+    <sequence>
+      <element name="name" type="domain:checkNameType" />
+      <element name="reason" type="eppcom:reasonType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <complexType name="checkNameType">
+    <simpleContent>
+      <extension base="eppcom:labelType">
+        <attribute name="avail" type="boolean"
+          use="required" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <!--
+<create> response elements.
+-->
+  <complexType name="creDataType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="crDate" type="dateTime" />
+      <element name="exDate" type="dateTime"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+<info> response elements.
+-->
+
+  <complexType name="infDataType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="roid" type="eppcom:roidType" />
+      <element name="status" type="domain:statusType"
+        minOccurs="0" maxOccurs="11" />
+      <element name="registrant" type="eppcom:clIDType"
+        minOccurs="0" />
+      <element name="contact" type="domain:contactType"
+        minOccurs="0" maxOccurs="unbounded" />
+      <element name="ns" type="domain:nsType"
+        minOccurs="0" />
+      <element name="host" type="eppcom:labelType"
+        minOccurs="0" maxOccurs="unbounded" />
+      <element name="clID" type="eppcom:clIDType" />
+      <element name="crID" type="eppcom:clIDType"
+        minOccurs="0" />
+      <element name="crDate" type="dateTime"
+        minOccurs="0" />
+      <element name="upID" type="eppcom:clIDType"
+        minOccurs="0" />
+      <element name="upDate" type="dateTime"
+        minOccurs="0" />
+      <element name="exDate" type="dateTime"
+        minOccurs="0" />
+      <element name="trDate" type="dateTime"
+        minOccurs="0" />
+      <element name="authInfo" type="domain:authInfoType"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+Status is a combination of attributes and an optional
+human-readable message that may be expressed in languages other
+than English.
+-->
+  <complexType name="statusType">
+    <simpleContent>
+      <extension base="normalizedString">
+        <attribute name="s" type="domain:statusValueType"
+          use="required" />
+        <attribute name="lang" type="language"
+          default="en" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <simpleType name="statusValueType">
+    <restriction base="token">
+      <enumeration value="clientDeleteProhibited" />
+      <enumeration value="clientHold" />
+      <enumeration value="clientRenewProhibited" />
+      <enumeration value="clientTransferProhibited" />
+      <enumeration value="clientUpdateProhibited" />
+      <enumeration value="inactive" />
+      <enumeration value="ok" />
+      <enumeration value="pendingCreate" />
+      <enumeration value="pendingDelete" />
+      <enumeration value="pendingRenew" />
+      <enumeration value="pendingTransfer" />
+      <enumeration value="pendingUpdate" />
+      <enumeration value="serverDeleteProhibited" />
+      <enumeration value="serverHold" />
+      <enumeration value="serverRenewProhibited" />
+      <enumeration value="serverTransferProhibited" />
+      <enumeration value="serverUpdateProhibited" />
+    </restriction>
+  </simpleType>
+
+  <!--
+Pending action notification response elements.
+-->
+  <complexType name="panDataType">
+    <sequence>
+      <element name="name" type="domain:paNameType" />
+      <element name="paTRID" type="epp:trIDType" />
+      <element name="paDate" type="dateTime" />
+    </sequence>
+  </complexType>
+
+  <complexType name="paNameType">
+    <simpleContent>
+      <extension base="eppcom:labelType">
+        <attribute name="paResult" type="boolean"
+          use="required" />
+      </extension>
+    </simpleContent>
+  </complexType>
+
+  <!--
+<renew> response elements.
+-->
+  <complexType name="renDataType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="exDate" type="dateTime"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+<transfer> response elements.
+-->
+  <complexType name="trnDataType">
+    <sequence>
+      <element name="name" type="eppcom:labelType" />
+      <element name="trStatus" type="eppcom:trStatusType" />
+      <element name="reID" type="eppcom:clIDType" />
+      <element name="reDate" type="dateTime" />
+      <element name="acID" type="eppcom:clIDType" />
+      <element name="acDate" type="dateTime" />
+      <element name="exDate" type="dateTime"
+        minOccurs="0" />
+    </sequence>
+  </complexType>
+
+  <!--
+End of schema.
+-->
+</schema>

--- a/epplib/tests/tests_ietf/data/schemas/epp-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/epp-1.0.xsd
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+  <schema targetNamespace="urn:ietf:params:xml:ns:epp-1.0"
+          xmlns:epp="urn:ietf:params:xml:ns:epp-1.0"
+          xmlns:eppcom="urn:ietf:params:xml:ns:eppcom-1.0"
+          xmlns="http://www.w3.org/2001/XMLSchema"
+          elementFormDefault="qualified">
+
+  <!--
+  Import common element types.
+  -->
+    <import namespace="urn:ietf:params:xml:ns:eppcom-1.0"
+            schemaLocation="eppcom-1.0.xsd"/>
+
+    <annotation>
+      <documentation>
+        Extensible Provisioning Protocol v1.0 schema.
+      </documentation>
+    </annotation>
+
+  <!--
+  Every EPP XML instance must begin with this element.
+  -->
+    <element name="epp" type="epp:eppType"/>
+
+  <!--
+  An EPP XML instance must contain a greeting, hello, command,
+  response, or extension.
+  -->
+    <complexType name="eppType">
+      <choice>
+        <element name="greeting" type="epp:greetingType"/>
+        <element name="hello"/>
+        <element name="command" type="epp:commandType"/>
+        <element name="response" type="epp:responseType"/>
+        <element name="extension" type="epp:extAnyType"/>
+      </choice>
+    </complexType>
+
+  <!--
+  A greeting is sent by a server in response to a client connection
+  or <hello>.
+  -->
+    <complexType name="greetingType">
+      <sequence>
+        <element name="svID" type="epp:sIDType"/>
+        <element name="svDate" type="dateTime"/>
+        <element name="svcMenu" type="epp:svcMenuType"/>
+        <element name="dcp" type="epp:dcpType"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  Server IDs are strings with minimum and maximum length restrictions.
+  -->
+    <simpleType name="sIDType">
+      <restriction base="normalizedString">
+        <minLength value="3"/>
+        <maxLength value="64"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  A server greeting identifies available object services.
+  -->
+    <complexType name="svcMenuType">
+      <sequence>
+        <element name="version" type="epp:versionType"
+         maxOccurs="unbounded"/>
+        <element name="lang" type="language"
+         maxOccurs="unbounded"/>
+        <element name="objURI" type="anyURI"
+         maxOccurs="unbounded"/>
+        <element name="svcExtension" type="epp:extURIType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  Data Collection Policy types.
+  -->
+
+    <complexType name="dcpType">
+      <sequence>
+        <element name="access" type="epp:dcpAccessType"/>
+        <element name="statement" type="epp:dcpStatementType"
+         maxOccurs="unbounded"/>
+        <element name="expiry" type="epp:dcpExpiryType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="dcpAccessType">
+      <choice>
+        <element name="all"/>
+        <element name="none"/>
+        <element name="null"/>
+        <element name="other"/>
+        <element name="personal"/>
+        <element name="personalAndOther"/>
+      </choice>
+    </complexType>
+
+    <complexType name="dcpStatementType">
+      <sequence>
+        <element name="purpose" type="epp:dcpPurposeType"/>
+        <element name="recipient" type="epp:dcpRecipientType"/>
+        <element name="retention" type="epp:dcpRetentionType"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="dcpPurposeType">
+      <sequence>
+        <element name="admin"
+         minOccurs="0"/>
+        <element name="contact"
+         minOccurs="0"/>
+        <element name="other"
+         minOccurs="0"/>
+        <element name="prov"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="dcpRecipientType">
+      <sequence>
+        <element name="other"
+         minOccurs="0"/>
+        <element name="ours" type="epp:dcpOursType"
+         minOccurs="0" maxOccurs="unbounded"/>
+        <element name="public"
+         minOccurs="0"/>
+        <element name="same"
+         minOccurs="0"/>
+        <element name="unrelated"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="dcpOursType">
+      <sequence>
+        <element name="recDesc" type="epp:dcpRecDescType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <simpleType name="dcpRecDescType">
+      <restriction base="token">
+        <minLength value="1"/>
+        <maxLength value="255"/>
+      </restriction>
+    </simpleType>
+
+    <complexType name="dcpRetentionType">
+      <choice>
+        <element name="business"/>
+        <element name="indefinite"/>
+        <element name="legal"/>
+        <element name="none"/>
+        <element name="stated"/>
+      </choice>
+    </complexType>
+
+    <complexType name="dcpExpiryType">
+      <choice>
+        <element name="absolute" type="dateTime"/>
+        <element name="relative" type="duration"/>
+      </choice>
+    </complexType>
+
+  <!--
+  Extension framework types.
+  -->
+    <complexType name="extAnyType">
+      <sequence>
+        <any namespace="##other"
+         maxOccurs="unbounded"/>
+      </sequence>
+
+    </complexType>
+
+    <complexType name="extURIType">
+      <sequence>
+        <element name="extURI" type="anyURI"
+         maxOccurs="unbounded"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  An EPP version number is a dotted pair of decimal numbers.
+  -->
+    <simpleType name="versionType">
+      <restriction base="token">
+        <pattern value="[1-9]+\.[0-9]+"/>
+        <enumeration value="1.0"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  Command types.
+  -->
+    <complexType name="commandType">
+      <sequence>
+        <choice>
+          <element name="check" type="epp:readWriteType"/>
+          <element name="create" type="epp:readWriteType"/>
+          <element name="delete" type="epp:readWriteType"/>
+          <element name="info" type="epp:readWriteType"/>
+          <element name="login" type="epp:loginType"/>
+          <element name="logout"/>
+          <element name="poll" type="epp:pollType"/>
+          <element name="renew" type="epp:readWriteType"/>
+          <element name="transfer" type="epp:transferType"/>
+          <element name="update" type="epp:readWriteType"/>
+        </choice>
+        <element name="extension" type="epp:extAnyType"
+         minOccurs="0"/>
+        <element name="clTRID" type="epp:trIDStringType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  The <login> command.
+  -->
+    <complexType name="loginType">
+      <sequence>
+        <element name="clID" type="eppcom:clIDType"/>
+        <element name="pw" type="epp:pwType"/>
+        <element name="newPW" type="epp:pwType"
+         minOccurs="0"/>
+        <element name="options" type="epp:credsOptionsType"/>
+        <element name="svcs" type="epp:loginSvcType"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="credsOptionsType">
+      <sequence>
+        <element name="version" type="epp:versionType"/>
+        <element name="lang" type="language"/>
+      </sequence>
+    </complexType>
+
+    <simpleType name="pwType">
+      <restriction base="token">
+        <minLength value="6"/>
+        <maxLength value="16"/>
+      </restriction>
+    </simpleType>
+
+    <complexType name="loginSvcType">
+      <sequence>
+        <element name="objURI" type="anyURI"
+         maxOccurs="unbounded"/>
+        <element name="svcExtension" type="epp:extURIType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  The <poll> command.
+  -->
+    <complexType name="pollType">
+      <attribute name="op" type="epp:pollOpType"
+       use="required"/>
+      <attribute name="msgID" type="token"/>
+    </complexType>
+
+    <simpleType name="pollOpType">
+      <restriction base="token">
+        <enumeration value="ack"/>
+        <enumeration value="req"/>
+      </restriction>
+    </simpleType>
+  <!--
+  The <transfer> command.  This is object-specific, and uses attributes
+  to identify the requested operation.
+  -->
+    <complexType name="transferType">
+      <sequence>
+        <any namespace="##other"/>
+      </sequence>
+      <attribute name="op" type="epp:transferOpType"
+       use="required"/>
+    </complexType>
+
+    <simpleType name="transferOpType">
+      <restriction base="token">
+        <enumeration value="request"/>
+        <enumeration value="approve"/>
+        <enumeration value="cancel"/>
+        <enumeration value="query"/>
+        <enumeration value="reject"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  All other object-centric commands. EPP doesn't specify the syntax or
+  semantics of object-centric command elements.  The elements MUST be
+  described in detail in another schema specific to the object.
+  -->
+    <complexType name="readWriteType">
+      <sequence>
+        <any namespace="##other"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="trIDType">
+      <sequence>
+        <element name="clTRID" type="epp:trIDStringType"
+         minOccurs="0"/>
+        <element name="svTRID" type="epp:trIDStringType"/>
+      </sequence>
+    </complexType>
+
+    <simpleType name="trIDStringType">
+      <restriction base="token">
+        <minLength value="3"/>
+        <maxLength value="64"/>
+      </restriction>
+    </simpleType>
+  <!--
+  Response types.
+  -->
+    <complexType name="responseType">
+      <sequence>
+        <element name="result" type="epp:resultType"
+         maxOccurs="unbounded"/>
+        <element name="msgQ" type="epp:msgQType"
+         minOccurs="0"/>
+        <element name="resData" type="epp:extAnyType"
+         minOccurs="0"/>
+        <element name="extension" type="epp:extAnyType"
+         minOccurs="0"/>
+        <element name="trID" type="epp:trIDType"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="resultType">
+      <sequence>
+        <element name="msg" type="epp:msgType"/>
+        <choice minOccurs="0" maxOccurs="unbounded">
+          <element name="value" type="epp:errValueType"/>
+          <element name="extValue" type="epp:extErrValueType"/>
+        </choice>
+      </sequence>
+      <attribute name="code" type="epp:resultCodeType"
+       use="required"/>
+    </complexType>
+
+    <complexType name="errValueType" mixed="true">
+      <sequence>
+        <any namespace="##any" processContents="skip"/>
+      </sequence>
+      <anyAttribute namespace="##any" processContents="skip"/>
+    </complexType>
+
+    <complexType name="extErrValueType">
+      <sequence>
+        <element name="value" type="epp:errValueType"/>
+        <element name="reason" type="epp:msgType"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="msgQType">
+      <sequence>
+        <element name="qDate" type="dateTime"
+         minOccurs="0"/>
+        <element name="msg" type="epp:mixedMsgType"
+         minOccurs="0"/>
+      </sequence>
+      <attribute name="count" type="unsignedLong"
+       use="required"/>
+      <attribute name="id" type="eppcom:minTokenType"
+       use="required"/>
+    </complexType>
+
+    <complexType name="mixedMsgType" mixed="true">
+      <sequence>
+        <any processContents="skip"
+         minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
+      <attribute name="lang" type="language"
+       default="en"/>
+    </complexType>
+
+  <!--
+  Human-readable text may be expressed in languages other than English.
+  -->
+    <complexType name="msgType">
+      <simpleContent>
+        <extension base="normalizedString">
+          <attribute name="lang" type="language"
+           default="en"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+  <!--
+  EPP result codes.
+  -->
+    <simpleType name="resultCodeType">
+      <restriction base="unsignedShort">
+        <enumeration value="1000"/>
+        <enumeration value="1001"/>
+        <enumeration value="1300"/>
+        <enumeration value="1301"/>
+        <enumeration value="1500"/>
+        <enumeration value="2000"/>
+        <enumeration value="2001"/>
+        <enumeration value="2002"/>
+        <enumeration value="2003"/>
+        <enumeration value="2004"/>
+        <enumeration value="2005"/>
+        <enumeration value="2100"/>
+        <enumeration value="2101"/>
+        <enumeration value="2102"/>
+        <enumeration value="2103"/>
+        <enumeration value="2104"/>
+        <enumeration value="2105"/>
+        <enumeration value="2106"/>
+        <enumeration value="2200"/>
+        <enumeration value="2201"/>
+        <enumeration value="2202"/>
+        <enumeration value="2300"/>
+        <enumeration value="2301"/>
+        <enumeration value="2302"/>
+        <enumeration value="2303"/>
+        <enumeration value="2304"/>
+        <enumeration value="2305"/>
+        <enumeration value="2306"/>
+        <enumeration value="2307"/>
+        <enumeration value="2308"/>
+        <enumeration value="2400"/>
+        <enumeration value="2500"/>
+        <enumeration value="2501"/>
+        <enumeration value="2502"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  End of schema.
+  -->
+  </schema>

--- a/epplib/tests/tests_ietf/data/schemas/eppcom-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/eppcom-1.0.xsd
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+  <schema targetNamespace="urn:ietf:params:xml:ns:eppcom-1.0"
+          xmlns:eppcom="urn:ietf:params:xml:ns:eppcom-1.0"
+          xmlns="http://www.w3.org/2001/XMLSchema"
+          elementFormDefault="qualified">
+
+    <annotation>
+      <documentation>
+        Extensible Provisioning Protocol v1.0
+        shared structures schema.
+      </documentation>
+    </annotation>
+
+  <!--
+  Object authorization information types.
+  -->
+    <complexType name="pwAuthInfoType">
+      <simpleContent>
+        <extension base="normalizedString">
+          <attribute name="roid" type="eppcom:roidType"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+    <complexType name="extAuthInfoType">
+      <sequence>
+        <any namespace="##other"/>
+      </sequence>
+    </complexType>
+
+  <!--
+  <check> response types.
+  -->
+    <complexType name="reasonType">
+      <simpleContent>
+        <extension base="eppcom:reasonBaseType">
+          <attribute name="lang" type="language"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+    <simpleType name="reasonBaseType">
+      <restriction base="token">
+        <minLength value="1"/>
+        <maxLength value="32"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  Abstract client and object identifier type.
+  -->
+    <simpleType name="clIDType">
+      <restriction base="token">
+        <minLength value="3"/>
+        <maxLength value="16"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  DNS label type.
+  -->
+    <simpleType name="labelType">
+      <restriction base="token">
+        <minLength value="1"/>
+        <maxLength value="255"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  Non-empty token type.
+  -->
+    <simpleType name="minTokenType">
+      <restriction base="token">
+        <minLength value="1"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  Repository Object IDentifier type.
+  -->
+    <simpleType name="roidType">
+      <restriction base="token">
+        <pattern value="(\w|_){1,80}-\w{1,8}"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  Transfer status identifiers.
+  -->
+    <simpleType name="trStatusType">
+      <restriction base="token">
+        <enumeration value="clientApproved"/>
+        <enumeration value="clientCancelled"/>
+        <enumeration value="clientRejected"/>
+        <enumeration value="pending"/>
+        <enumeration value="serverApproved"/>
+        <enumeration value="serverCancelled"/>
+      </restriction>
+    </simpleType>
+
+  <!--
+  End of schema.
+  -->
+  </schema>
+
+
+
+
+
+

--- a/epplib/tests/tests_ietf/data/schemas/host-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/host-1.0.xsd
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+   <schema targetNamespace="urn:ietf:params:xml:ns:host-1.0"
+          xmlns:host="urn:ietf:params:xml:ns:host-1.0"
+          xmlns:epp="urn:ietf:params:xml:ns:epp-1.0"
+          xmlns:eppcom="urn:ietf:params:xml:ns:eppcom-1.0"
+          xmlns="http://www.w3.org/2001/XMLSchema"
+          elementFormDefault="qualified">
+
+   <!--
+   Import common element types.
+   -->
+    <import namespace="urn:ietf:params:xml:ns:eppcom-1.0"/>
+    <import namespace="urn:ietf:params:xml:ns:epp-1.0"/>
+
+    <annotation>
+      <documentation>
+        Extensible Provisioning Protocol v1.0
+        host provisioning schema.
+      </documentation>
+    </annotation>
+
+   <!--
+   Child elements found in EPP commands.
+   -->
+    <element name="check" type="host:mNameType"/>
+    <element name="create" type="host:createType"/>
+    <element name="delete" type="host:sNameType"/>
+    <element name="info" type="host:sNameType"/>
+    <element name="update" type="host:updateType"/>
+
+   <!--
+   Child elements of the <create> command.
+   -->
+    <complexType name="createType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+        <element name="addr" type="host:addrType"
+         minOccurs="0" maxOccurs="unbounded"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="addrType">
+      <simpleContent>
+        <extension base="host:addrStringType">
+          <attribute name="ip" type="host:ipType"
+           default="v4"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+    <simpleType name="addrStringType">
+      <restriction base="token">
+        <minLength value="3"/>
+        <maxLength value="45"/>
+      </restriction>
+    </simpleType>
+
+    <simpleType name="ipType">
+      <restriction base="token">
+        <enumeration value="v4"/>
+        <enumeration value="v6"/>
+      </restriction>
+    </simpleType>
+
+   <!--
+   Child elements of the <delete> and <info> commands.
+   -->
+    <complexType name="sNameType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Child element of commands that accept multiple names.
+   -->
+    <complexType name="mNameType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"
+         maxOccurs="unbounded"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Child elements of the <update> command.
+   -->
+    <complexType name="updateType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+        <element name="add" type="host:addRemType"
+         minOccurs="0"/>
+        <element name="rem" type="host:addRemType"
+         minOccurs="0"/>
+        <element name="chg" type="host:chgType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Data elements that can be added or removed.
+   -->
+    <complexType name="addRemType">
+      <sequence>
+        <element name="addr" type="host:addrType"
+         minOccurs="0" maxOccurs="unbounded"/>
+        <element name="status" type="host:statusType"
+         minOccurs="0" maxOccurs="7"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Data elements that can be changed.
+   -->
+    <complexType name="chgType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Child response elements.
+   -->
+    <element name="chkData" type="host:chkDataType"/>
+    <element name="creData" type="host:creDataType"/>
+    <element name="infData" type="host:infDataType"/>
+    <element name="panData" type="host:panDataType"/>
+
+   <!--
+   <check> response elements.
+   -->
+    <complexType name="chkDataType">
+      <sequence>
+        <element name="cd" type="host:checkType"
+         maxOccurs="unbounded"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="checkType">
+      <sequence>
+        <element name="name" type="host:checkNameType"/>
+        <element name="reason" type="eppcom:reasonType"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="checkNameType">
+      <simpleContent>
+        <extension base="eppcom:labelType">
+          <attribute name="avail" type="boolean"
+           use="required"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+   <!--
+   <create> response elements.
+   -->
+    <complexType name="creDataType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+        <element name="crDate" type="dateTime"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   <info> response elements.
+   -->
+    <complexType name="infDataType">
+      <sequence>
+        <element name="name" type="eppcom:labelType"/>
+        <element name="roid" type="eppcom:roidType"/>
+        <element name="status" type="host:statusType"
+         maxOccurs="7"/>
+        <element name="addr" type="host:addrType"
+         minOccurs="0" maxOccurs="unbounded"/>
+        <element name="clID" type="eppcom:clIDType"/>
+        <element name="crID" type="eppcom:clIDType"/>
+        <element name="crDate" type="dateTime"/>
+        <element name="upID" type="eppcom:clIDType"
+         minOccurs="0"/>
+        <element name="upDate" type="dateTime"
+         minOccurs="0"/>
+        <element name="trDate" type="dateTime"
+         minOccurs="0"/>
+      </sequence>
+    </complexType>
+
+   <!--
+   Status is a combination of attributes and an optional human-readable
+   message that may be expressed in languages other than English.
+   -->
+    <complexType name="statusType">
+      <simpleContent>
+        <extension base="normalizedString">
+          <attribute name="s" type="host:statusValueType"
+           use="required"/>
+          <attribute name="lang" type="language"
+           default="en"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+    <simpleType name="statusValueType">
+      <restriction base="token">
+        <enumeration value="clientDeleteProhibited"/>
+        <enumeration value="clientUpdateProhibited"/>
+        <enumeration value="linked"/>
+        <enumeration value="ok"/>
+        <enumeration value="pendingCreate"/>
+        <enumeration value="pendingDelete"/>
+        <enumeration value="pendingTransfer"/>
+        <enumeration value="pendingUpdate"/>
+        <enumeration value="serverDeleteProhibited"/>
+        <enumeration value="serverUpdateProhibited"/>
+      </restriction>
+    </simpleType>
+
+   <!--
+   Pending action notification response elements.
+   -->
+    <complexType name="panDataType">
+      <sequence>
+        <element name="name" type="host:paNameType"/>
+        <element name="paTRID" type="epp:trIDType"/>
+        <element name="paDate" type="dateTime"/>
+      </sequence>
+    </complexType>
+
+    <complexType name="paNameType">
+      <simpleContent>
+        <extension base="eppcom:labelType">
+          <attribute name="paResult" type="boolean"
+           use="required"/>
+        </extension>
+      </simpleContent>
+    </complexType>
+
+   <!--
+   End of schema.
+   -->
+   </schema>

--- a/epplib/tests/tests_ietf/test_commands_check.py
+++ b/epplib/tests/tests_ietf/test_commands_check.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2021  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands import CheckHost
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+
+
+class TestCheckHost(XMLTestCase):
+    hosts = ['ns1.domain.cz', 'ns1.other.com']
+
+    def test_valid(self):
+        self.assertRequestValid(CheckHost, {'names': self.hosts}, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(CheckHost(self.hosts).xml())
+        host = ElementMaker(namespace=NAMESPACE.NIC_HOST)
+        expected = make_epp_root(
+            EM.command(
+                EM.check(
+                    host.check(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_HOST},
+                        *[host.name(item) for item in self.hosts]
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)

--- a/epplib/tests/tests_ietf/test_commands_create.py
+++ b/epplib/tests/tests_ietf/test_commands_create.py
@@ -1,0 +1,148 @@
+#
+# Copyright (C) 2021-2023  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+from typing import Any, Dict
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands import CreateContact, CreateDomain, CreateHost
+from epplib.models.common import ContactAuthInfo, DomainAuthInfo
+from epplib.models import ContactAddr, Ip
+from epplib.models.create import CreatePostalInfo
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+
+
+@patch('epplib.commands.create.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.create.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.DomainAuthInfo.namespace', NAMESPACE.NIC_DOMAIN)
+class TestCreateDomain(XMLTestCase):
+    params: Dict[str, Any] = {
+        'name': 'thisdomain.cz',
+        'registrant': 'CID-MYOWN',
+        'auth_info': DomainAuthInfo(pw='2fooBAR123fooBaz'),
+    }
+
+    def test_valid(self):
+        self.assertRequestValid(CreateDomain, self.params, schema=SCHEMA)
+
+    def test_data_auth_info_object(self):
+        root = fromstring(CreateDomain(**self.params).xml())
+        domain = ElementMaker(namespace=NAMESPACE.NIC_DOMAIN)
+        expected = make_epp_root(
+            EM.command(
+                EM.create(
+                    domain.create(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_DOMAIN},
+                        domain.name(self.params['name']),
+                        domain.registrant(self.params['registrant']),
+                        domain.authInfo(
+                            domain.pw(self.params['auth_info'].pw),
+                        ),
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+@patch('epplib.commands.create.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.create.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.ContactAuthInfo.namespace', NAMESPACE.NIC_CONTACT)
+@patch('epplib.models.create.CreatePostalInfo.namespace', NAMESPACE.NIC_CONTACT)
+@patch('epplib.models.ContactAddr.namespace', NAMESPACE.NIC_CONTACT)
+class TestCreateContact(XMLTestCase):
+    params: Dict[str, Any] = {
+        'id': 'CID-MYCONTACT',
+        'postal_info': CreatePostalInfo(
+            'John Doe',
+            ContactAddr(
+               ['Street 123'],
+               'City',
+               '12300',
+               'CZ'
+            ),
+            type='loc'
+        ),
+        'email': 'john@doe.cz',
+        'auth_info': ContactAuthInfo(pw='2fooBAR123fooBaz'),
+    }
+
+    def test_valid(self):
+        self.assertRequestValid(CreateContact, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(CreateContact(**self.params).xml())
+        contact = ElementMaker(namespace=NAMESPACE.NIC_CONTACT)
+        expected = make_epp_root(
+            EM.command(
+                EM.create(
+                    contact.create(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_CONTACT},
+                        contact.id(self.params['id']),
+                        contact.postalInfo(
+                            {'type': self.params['postal_info'].type},
+                            contact.name(self.params['postal_info'].name),
+                            contact.addr(
+                                contact.street(self.params['postal_info'].addr.street[0]),
+                                contact.city(self.params['postal_info'].addr.city),
+                                contact.pc(self.params['postal_info'].addr.pc),
+                                contact.cc(self.params['postal_info'].addr.cc),
+                            ),
+                        ),
+                        contact.email(self.params['email']),
+                        contact.authInfo(
+                            contact.pw(self.params['auth_info'].pw),
+                        ),
+                    ),
+                ),
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+class TestCreateHost(XMLTestCase):
+    params: Dict[str, Any] = {
+        'name': 'ns1.thisdomain.cz',
+        'addrs': [
+            Ip('192.0.2.2'),
+            Ip('1080:0:0:0:8:800:200C:417A', 'v6'),
+        ],
+    }
+
+    def test_valid(self):
+        self.assertRequestValid(CreateHost, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(CreateHost(**self.params).xml())
+        host = ElementMaker(namespace=NAMESPACE.NIC_HOST)
+        expected = make_epp_root(
+            EM.command(
+                EM.create(
+                    host.create(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_HOST},
+                        host.name(self.params['name']),
+                        *[addr.get_payload() for addr in self.params['addrs']],
+                    ),
+                ),
+            )
+        )
+        self.assertXMLEqual(root, expected)

--- a/epplib/tests/tests_ietf/test_commands_delete.py
+++ b/epplib/tests/tests_ietf/test_commands_delete.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2021  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands import DeleteHost
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+
+
+class TestDeleteHost(XMLTestCase):
+    host = 'domain.cz'
+
+    def test_valid(self):
+        self.assertRequestValid(DeleteHost, {'name': self.host}, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(DeleteHost(self.host).xml())
+        host = ElementMaker(namespace=NAMESPACE.NIC_HOST)
+        expected = make_epp_root(
+            EM.command(
+                EM.delete(
+                    host.delete(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_HOST},
+                        host.name(self.host)
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)

--- a/epplib/tests/tests_ietf/test_commands_info.py
+++ b/epplib/tests/tests_ietf/test_commands_info.py
@@ -1,0 +1,115 @@
+#
+# Copyright (C) 2021-2022  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands.info import InfoContact, InfoDomain, InfoHost
+from epplib.models.common import ContactAuthInfo, DomainAuthInfo
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+
+
+@patch('epplib.commands.info.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.info.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.DomainAuthInfo.namespace', NAMESPACE.NIC_DOMAIN)
+class TestInfoDomain(XMLTestCase):
+
+    def setUp(self) -> None:
+        """Setup params."""
+        self.params = {'name': 'mydoma.in', 'auth_info': DomainAuthInfo(pw='2fooBAR123fooBaz')}
+
+    def test_valid(self):
+        self.assertRequestValid(InfoDomain, self.params, schema=SCHEMA)
+
+    def test_data_auth_info_object(self):
+        root = fromstring(InfoDomain(**self.params).xml())
+        domain = ElementMaker(namespace=NAMESPACE.NIC_DOMAIN)
+        expected = make_epp_root(
+            EM.command(
+                EM.info(
+                    domain.info(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_DOMAIN},
+                        domain.name(self.params['name']),
+                        domain.authInfo(
+                            domain.pw(self.params['auth_info'].pw),
+                        ),
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+@patch('epplib.commands.info.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.info.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.ContactAuthInfo.namespace', NAMESPACE.NIC_CONTACT)
+class TestInfoContact(XMLTestCase):
+
+    def setUp(self) -> None:
+        """Setup params."""
+        self.params = {'id': 'CID-MYCONTACT', 'auth_info': ContactAuthInfo(pw='2fooBAR123fooBaz')}
+
+
+    def test_valid(self):
+        self.assertRequestValid(InfoContact, self.params, schema=SCHEMA)
+
+    def test_data_auth_info_object(self):
+        root = fromstring(InfoContact(**self.params).xml())
+        contact = ElementMaker(namespace=NAMESPACE.NIC_CONTACT)
+        expected = make_epp_root(
+            EM.command(
+                EM.info(
+                    contact.info(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_CONTACT},
+                        contact.id(self.params['id']),
+                        contact.authInfo(
+                            contact.pw(self.params['auth_info'].pw)
+                        ),
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+class TestInfoHost(XMLTestCase):
+
+    def setUp(self) -> None:
+        """Setup params."""
+        self.params = {'name': 'ns1.mydoma.in'}
+
+    def test_valid(self):
+        self.assertRequestValid(InfoHost, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(InfoHost(**self.params).xml())
+        host = ElementMaker(namespace=NAMESPACE.NIC_HOST)
+        expected = make_epp_root(
+            EM.command(
+                EM.info(
+                    host.info(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_HOST},
+                        host.name(self.params['name']),
+                    )
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)

--- a/epplib/tests/tests_ietf/test_commands_transfer.py
+++ b/epplib/tests/tests_ietf/test_commands_transfer.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2021  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands import TransferContact, TransferDomain
+from epplib.models.common import ContactAuthInfo, DomainAuthInfo
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+
+
+@patch('epplib.commands.transfer.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.transfer.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.DomainAuthInfo.namespace', NAMESPACE.NIC_DOMAIN)
+class TestTransferDomain(XMLTestCase):
+    params = {'name': 'trdomain.cz', 'auth_info': DomainAuthInfo(pw='2fooBAR123fooBaz')}
+
+    def test_valid(self):
+        self.assertRequestValid(TransferDomain, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(TransferDomain(**self.params).xml())
+        domain = ElementMaker(namespace=NAMESPACE.NIC_DOMAIN)
+        expected = make_epp_root(
+            EM.command(
+                EM.transfer(
+                    domain.transfer(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_DOMAIN},
+                        domain.name(self.params['name']),
+                        domain.authInfo(
+                            domain.pw(self.params['auth_info'].pw),
+                        ),
+                    ),
+                    op='request',
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+@patch('epplib.commands.transfer.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.transfer.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.ContactAuthInfo.namespace', NAMESPACE.NIC_CONTACT)
+class TestTransferContact(XMLTestCase):
+    params = {'id': 'CID-TRCONT', 'auth_info': ContactAuthInfo(pw='2fooBAR123fooBaz')}
+
+    def test_valid(self):
+        self.assertRequestValid(TransferContact, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(TransferContact(**self.params).xml())
+        contact = ElementMaker(namespace=NAMESPACE.NIC_CONTACT)
+        expected = make_epp_root(
+            EM.command(
+                EM.transfer(
+                    contact.transfer(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_CONTACT},
+                        contact.id(self.params['id']),
+                        contact.authInfo(
+                            contact.pw(self.params['auth_info'].pw),
+                        ),
+                    ),
+                    op='request',
+                )
+            )
+        )
+        self.assertXMLEqual(root, expected)
+

--- a/epplib/tests/tests_ietf/test_commands_update.py
+++ b/epplib/tests/tests_ietf/test_commands_update.py
@@ -1,0 +1,181 @@
+#
+# Copyright (C) 2021-2022  CZ.NIC, z. s. p. o.
+#
+# This file is part of FRED.
+#
+# FRED is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FRED is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FRED.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+from typing import Any, Dict
+
+from lxml.builder import ElementMaker
+from lxml.etree import QName, fromstring
+
+from epplib.commands import UpdateContact, UpdateDomain, UpdateHost
+from epplib.models.common import ContactAuthInfo, DomainAuthInfo, DomainContact, HostObjSet, HostStatus, Ip, Status
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+from epplib.tests.utils import EM, XMLTestCase, make_epp_root
+
+
+@patch('epplib.commands.update.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.update.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.DomainAuthInfo.namespace', NAMESPACE.NIC_DOMAIN)
+@patch('epplib.models.common.DomainContact.namespace', NAMESPACE.NIC_DOMAIN)
+@patch('epplib.models.common.HostObjSet.namespace', NAMESPACE.NIC_DOMAIN)
+@patch('epplib.models.common.Status.namespace', NAMESPACE.NIC_DOMAIN)
+class TestUpdateDomain(XMLTestCase):
+    params: Dict[str, Any] = {
+        'name': 'thisdomain.cz',
+        'add': [
+            Status('clientTransferProhibited', None),
+            DomainContact('CID-MYCONTA', 'tech'),
+            HostObjSet(['ns1.thisdomain.cz', 'ns2.thisdomain.cz'])
+        ],
+        'rem': [
+            Status('clientUpdateProhibited', None),
+            DomainContact('CID-MYCONTT', 'admin'),
+            HostObjSet(['ns3.thisdomain.cz', 'ns4.thisdomain.cz'])
+        ],
+        'auth_info': DomainAuthInfo(pw='2fooBAR123fooBaz')
+    }
+
+    def test_data(self):
+        root = fromstring(UpdateDomain(**self.params).xml())
+        domain = ElementMaker(namespace=NAMESPACE.NIC_DOMAIN)
+        expected = make_epp_root(
+            EM.command(
+                EM.update(
+                    domain.update(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_DOMAIN},
+                        domain.name(self.params['name']),
+                        domain.add(
+                            domain.status({'s': 'clientTransferProhibited'}),
+                            domain.contact(
+                                {'type': 'tech'},
+                                'CID-MYCONTA'
+                            ),
+                            domain.ns(
+                                domain.hostObj('ns1.thisdomain.cz'),
+                                domain.hostObj('ns2.thisdomain.cz'),
+                            ),
+                        ),
+                        domain.rem(
+                            domain.status({'s': 'clientUpdateProhibited'}),
+                            domain.contact(
+                                {'type': 'admin'},
+                                'CID-MYCONTT'
+                            ),
+                            domain.ns(
+                                domain.hostObj('ns3.thisdomain.cz'),
+                                domain.hostObj('ns4.thisdomain.cz'),
+                            ),
+                        ),
+                        domain.chg(
+                            domain.authInfo(
+                                domain.pw(self.params['auth_info'].pw),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+@patch('epplib.commands.update.NAMESPACE', NAMESPACE)
+@patch('epplib.commands.update.SCHEMA_LOCATION', SCHEMA_LOCATION)
+@patch('epplib.models.common.ContactAuthInfo.namespace', NAMESPACE.NIC_CONTACT)
+class TestUpdateContact(XMLTestCase):
+    params: Dict[str, Any] = {
+        'id': 'CID-MYCONTA',
+        'auth_info': ContactAuthInfo(pw='2fooBAR123fooBaz'),
+    }
+
+    def test_valid(self):
+        self.assertRequestValid(UpdateContact, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(UpdateContact(**self.params).xml())
+        contact = ElementMaker(namespace=NAMESPACE.NIC_CONTACT)
+        expected = make_epp_root(
+            EM.command(
+                EM.update(
+                    contact.update(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_CONTACT},
+                        contact.id(self.params['id']),
+                        contact.chg(
+                            contact.authInfo(
+                                contact.pw(self.params['auth_info'].pw),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+        self.assertXMLEqual(root, expected)
+
+
+class TestUpdateHost(XMLTestCase):
+    params: Dict[str, Any] = {
+        'name': 'ns1.thisdomain.cz',
+        'add': [
+            Ip(addr='192.0.2.2'),
+            Ip(addr='1080:0:0:0:8:800:200C:417A', ip='v6'),
+            HostStatus('clientDeleteProhibited'),
+        ],
+        'rem': [
+            Ip(addr='192.0.3.3'),
+            Ip(addr='2080:0:0:0:8:800:200D:417E', ip='v6'),
+            HostStatus('clientUpdateProhibited'),
+        ],
+        'chg': 'ns2.thisdomain.cz'
+    }
+
+    def test_valid(self):
+        self.assertRequestValid(UpdateHost, self.params, schema=SCHEMA)
+
+    def test_data(self):
+        root = fromstring(UpdateHost(**self.params).xml())
+        host = ElementMaker(namespace=NAMESPACE.NIC_HOST)
+        expected = make_epp_root(
+            EM.command(
+                EM.update(
+                    host.update(
+                        {QName(NAMESPACE.XSI, 'schemaLocation'): SCHEMA_LOCATION.NIC_HOST},
+                        host.name(self.params['name']),
+                        host.add(
+                            host.addr('192.0.2.2'),
+                            host.addr(
+                                {'ip': 'v6'},
+                                '1080:0:0:0:8:800:200C:417A',
+                            ),
+                            host.status({'s': 'clientDeleteProhibited'}),
+                        ),
+                        host.rem(
+                            host.addr('192.0.3.3'),
+                            host.addr(
+                                {'ip': 'v6'},
+                                '2080:0:0:0:8:800:200D:417E',
+                            ),
+                            host.status({'s': 'clientUpdateProhibited'}),
+                        ),
+                        host.chg(
+                            host.name(self.params['chg']),
+                        ),
+                    ),
+                ),
+            )
+        )
+        self.assertXMLEqual(root, expected)

--- a/epplib/tests/utils.py
+++ b/epplib/tests/utils.py
@@ -55,13 +55,13 @@ class XMLTestCase(TestCase):
     """TestCase with aditional methods for testing xml trees."""
 
     def assertRequestValid(self, request_class: Type[Request], params: Mapping[str, Any],
-                           extension: Optional[CommandExtension] = None) -> None:
+                           extension: Optional[CommandExtension] = None, schema = None) -> None:
         """Assert that the generated XML complies with the schema."""
         request = request_class(**params)
         if extension is not None:
             cast(Command, request).add_extension(extension)
         xml = request.xml(tr_id='tr_id_123')
-        SCHEMA.assertValid(safe_parse(xml))
+        (schema or SCHEMA).assertValid(safe_parse(xml))
 
     def assertXMLEqual(self, doc_1: Element, doc_2: Element) -> None:
         try:

--- a/epplib/utils.py
+++ b/epplib/utils.py
@@ -57,6 +57,7 @@ class ParseXMLMixin:
         'fred': NAMESPACE.FRED,
         'contact': NAMESPACE.NIC_CONTACT,
         'domain': NAMESPACE.NIC_DOMAIN,
+        'host': NAMESPACE.NIC_HOST,
         'keyset': NAMESPACE.NIC_KEYSET,
         'nsset': NAMESPACE.NIC_NSSET,
     }


### PR DESCRIPTION
This pull request introduces (partial) [STD 69](https://www.rfc-editor.org/std/std69.txt) support, while **preserving the original library interface**.

The original test suite is unmodified and passes.

```
mkvirtualenv epplib
pip install -e ".[quality,test,types]"
python -m unittest
```

CHANGELOG

* Introduction of `NIC_HOST` constant
* Introduction of Host commands: `CheckHost`, `CreateHost`, `DeleteHost`, `InfoHost`, `UpdateHost`
* Modification of `auth_info` to support a `pw` subelement
* Modification of `*Domain` commands to support new models: `Status`, `DomainContact`, `HostObjSet`
* Modification of `Disclose` to support `type` attribute
* Modification of `PostalInfo` to support `type` attribute
* Addition of a new test suite in `tests/tests_ietf` to test these modifications