### PR TITLE
Issue 809 - XML Contact Parsing bug

### DIFF
--- a/epplib/models/common.py
+++ b/epplib/models/common.py
@@ -40,6 +40,7 @@ class DiscloseField(str, Enum):
     VAT = "vat"
     IDENT = "ident"
     NOTIFY_EMAIL = "notifyEmail"
+    NAME = "name"
 
 
 @unique

--- a/epplib/models/info.py
+++ b/epplib/models/info.py
@@ -128,12 +128,11 @@ class InfoDomainResultData(InfoResultData):
     keyset: Optional[str]
     ex_date: Optional[date]
     auth_info: Optional[Union[str, DomainAuthInfo]]
-    hosts: InitVar[Optional[List[str]]] = None
+    hosts: Optional[List[str]] = field(default=None, repr=True)
     contacts: Optional[List[str]] = field(default=None, repr=True)
 
-    def __post_init__(self, hosts) -> None:
-        print("in init")
-        self.hosts = hosts or []
+    def __post_init__(self) -> None:
+        self.hosts = self.hosts or []
         self.contacts = self.contacts or []
 
     @classmethod
@@ -158,7 +157,7 @@ class InfoDomainResultData(InfoResultData):
         print(contacts)
         if ns is not None:
             params["hosts"] = cls._find_all_text(ns, f"./{cls._namespace}:hostObj")
-        if contacts is not None:
+        if contacts is not None and contacts != []:
             params["contacts"] = [DomainContact.extract(item) for item in contacts]
             print(params["contacts"])
         return {**super()._get_params(element), **params}

--- a/epplib/models/info.py
+++ b/epplib/models/info.py
@@ -129,12 +129,12 @@ class InfoDomainResultData(InfoResultData):
     ex_date: Optional[date]
     auth_info: Optional[Union[str, DomainAuthInfo]]
     hosts: InitVar[Optional[List[str]]] = None
-    contacts: InitVar[Optional[List[str]]] = None
+    contacts: Optional[List[str]] = field(default=None, repr=True)
 
-    def __post_init__(self, hosts, contacts) -> None:
+    def __post_init__(self, hosts) -> None:
         print("in init")
         self.hosts = hosts or []
-        self.contacts = contacts or []
+        self.contacts = self.contacts or []
 
     @classmethod
     def _get_params(cls, element: Element) -> Mapping[str, Any]:

--- a/epplib/models/info.py
+++ b/epplib/models/info.py
@@ -158,7 +158,7 @@ class InfoDomainResultData(InfoResultData):
         print(contacts)
         if ns is not None:
             params["hosts"] = cls._find_all_text(ns, f"./{cls._namespace}:hostObj")
-        if contacts:
+        if contacts is not None:
             params["contacts"] = [DomainContact.extract(item) for item in contacts]
             print(params["contacts"])
         return {**super()._get_params(element), **params}

--- a/epplib/models/info.py
+++ b/epplib/models/info.py
@@ -69,10 +69,12 @@ class InfoResultData(ExtractModelMixin):
     @classmethod
     def extract(cls, element: Element) -> "InfoResultData":
         """Extract params for own init from the element."""
+        print("calling extract")
         return cls(**cls._get_params(element))
 
     @classmethod
     def _get_params(cls, element: Element) -> Mapping[str, Any]:
+        print("get params")
         params: Mapping[str, Any] = {
             "roid": cls._find_text(element, f"./{cls._namespace}:roid"),
             "statuses": [
@@ -116,7 +118,7 @@ class InfoDomainResultData(InfoResultData):
         hosts: Content of the epp/response/resData/infData/ns/hostObj element.
         contacts: Content of the epp/response/resData/infData/contact element.
     """
-
+##here is where to edit
     _namespace = "domain"
 
     name: str
@@ -130,11 +132,13 @@ class InfoDomainResultData(InfoResultData):
     contacts: InitVar[Optional[List[str]]] = None
 
     def __post_init__(self, hosts, contacts) -> None:
+        print("in init")
         self.hosts = hosts or []
         self.contacts = contacts or []
 
     @classmethod
     def _get_params(cls, element: Element) -> Mapping[str, Any]:
+        print("mapping")
         params: Mapping[str, Any] = {
             "name": cls._find_text(element, f"./{cls._namespace}:name"),
             "registrant": cls._find_text(element, f"./{cls._namespace}:registrant"),
@@ -151,10 +155,12 @@ class InfoDomainResultData(InfoResultData):
         }
         ns = cls._find(element, f"./{InfoDomainResultData._namespace}:ns")
         contacts = cls._find_all(element, f"./{cls._namespace}:contact")
+        print(contacts)
         if ns is not None:
             params["hosts"] = cls._find_all_text(ns, f"./{cls._namespace}:hostObj")
         if contacts:
             params["contacts"] = [DomainContact.extract(item) for item in contacts]
+            print(params["contacts"])
         return {**super()._get_params(element), **params}
 
 

--- a/epplib/models/info.py
+++ b/epplib/models/info.py
@@ -69,12 +69,10 @@ class InfoResultData(ExtractModelMixin):
     @classmethod
     def extract(cls, element: Element) -> "InfoResultData":
         """Extract params for own init from the element."""
-        print("calling extract")
         return cls(**cls._get_params(element))
 
     @classmethod
     def _get_params(cls, element: Element) -> Mapping[str, Any]:
-        print("get params")
         params: Mapping[str, Any] = {
             "roid": cls._find_text(element, f"./{cls._namespace}:roid"),
             "statuses": [
@@ -118,7 +116,6 @@ class InfoDomainResultData(InfoResultData):
         hosts: Content of the epp/response/resData/infData/ns/hostObj element.
         contacts: Content of the epp/response/resData/infData/contact element.
     """
-##here is where to edit
     _namespace = "domain"
 
     name: str
@@ -137,7 +134,6 @@ class InfoDomainResultData(InfoResultData):
 
     @classmethod
     def _get_params(cls, element: Element) -> Mapping[str, Any]:
-        print("mapping")
         params: Mapping[str, Any] = {
             "name": cls._find_text(element, f"./{cls._namespace}:name"),
             "registrant": cls._find_text(element, f"./{cls._namespace}:registrant"),
@@ -154,12 +150,10 @@ class InfoDomainResultData(InfoResultData):
         }
         ns = cls._find(element, f"./{InfoDomainResultData._namespace}:ns")
         contacts = cls._find_all(element, f"./{cls._namespace}:contact")
-        print(contacts)
         if ns is not None:
             params["hosts"] = cls._find_all_text(ns, f"./{cls._namespace}:hostObj")
         if contacts is not None and contacts != []:
             params["contacts"] = [DomainContact.extract(item) for item in contacts]
-            print(params["contacts"])
         return {**super()._get_params(element), **params}
 
 

--- a/epplib/responses/base.py
+++ b/epplib/responses/base.py
@@ -90,10 +90,10 @@ class Response(ParseXMLMixin, ABC):
                 raw data received from the server to ease the debugging.
         """
         root = safe_parse(raw_response)
-
+        print("after safe parse")
         if schema is not None:
             schema.assertValid(root)
-
+            print("checked if valid")
         if root.tag != QName(NAMESPACE.EPP, "epp"):
             raise ValueError('Root element has to be "epp". Found: {}'.format(root.tag))
 
@@ -105,7 +105,9 @@ class Response(ParseXMLMixin, ABC):
                 )
             )
         try:
+            print("extracting payload")
             data = cls._extract_payload(payload)
+            print("data is %s"%data)
         except Exception as exception:
             raise ParsingError(raw_response=raw_response) from exception
 
@@ -311,6 +313,9 @@ class Result(Response, Generic[T]):
             raw_response: The raw XML response which will be parsed into the Response object.
             schema: A XML schema used to validate the parsed Response. No validation is done if schema is None.
         """
+        print("in super of parse")
+        print(raw_response)
+        print(schema)
         return super().parse(raw_response, schema)
 
     @classmethod
@@ -320,6 +325,7 @@ class Result(Response, Generic[T]):
         Args:
             element: Child element of the epp element.
         """
+        print("payload extract in Result object")
         payload_data = {
             "code": cls._optional(
                 int, cls._find_attrib(element, "./epp:result", "code")
@@ -333,6 +339,8 @@ class Result(Response, Generic[T]):
             ),
             "msg_q": cls._extract_message(cls._find(element, "./epp:msgQ")),
         }
+        print("resdata %s"%cls._extract_data(cls._find(element, "./epp:resData")))
+        print("resdata %s"%cls._extract_data(cls._find(element, "./resData")))
         return payload_data
 
     @classmethod
@@ -350,7 +358,11 @@ class Result(Response, Generic[T]):
             data = None
         else:
             data = []
+            print("IN _extract ")
+            print(cls._NAMESPACES)
+            print(cls._res_data_path)
             for item in element.findall(cls._res_data_path, namespaces=cls._NAMESPACES):
+                print(item)
                 item_data = cast(T, cls._res_data_class.extract(item))
                 data.append(item_data)
         return data

--- a/epplib/responses/base.py
+++ b/epplib/responses/base.py
@@ -90,10 +90,8 @@ class Response(ParseXMLMixin, ABC):
                 raw data received from the server to ease the debugging.
         """
         root = safe_parse(raw_response)
-        print("after safe parse")
         if schema is not None:
             schema.assertValid(root)
-            print("checked if valid")
         if root.tag != QName(NAMESPACE.EPP, "epp"):
             raise ValueError('Root element has to be "epp". Found: {}'.format(root.tag))
 
@@ -105,9 +103,7 @@ class Response(ParseXMLMixin, ABC):
                 )
             )
         try:
-            print("extracting payload")
             data = cls._extract_payload(payload)
-            print("data is %s"%data)
         except Exception as exception:
             raise ParsingError(raw_response=raw_response) from exception
 
@@ -313,9 +309,6 @@ class Result(Response, Generic[T]):
             raw_response: The raw XML response which will be parsed into the Response object.
             schema: A XML schema used to validate the parsed Response. No validation is done if schema is None.
         """
-        print("in super of parse")
-        print(raw_response)
-        print(schema)
         return super().parse(raw_response, schema)
 
     @classmethod
@@ -325,7 +318,6 @@ class Result(Response, Generic[T]):
         Args:
             element: Child element of the epp element.
         """
-        print("payload extract in Result object")
         payload_data = {
             "code": cls._optional(
                 int, cls._find_attrib(element, "./epp:result", "code")
@@ -339,8 +331,6 @@ class Result(Response, Generic[T]):
             ),
             "msg_q": cls._extract_message(cls._find(element, "./epp:msgQ")),
         }
-        print("resdata %s"%cls._extract_data(cls._find(element, "./epp:resData")))
-        print("resdata %s"%cls._extract_data(cls._find(element, "./resData")))
         return payload_data
 
     @classmethod
@@ -358,11 +348,7 @@ class Result(Response, Generic[T]):
             data = None
         else:
             data = []
-            print("IN _extract printing")
-            print(cls._NAMESPACES)
-            print(cls._res_data_path)
             for item in element.findall(cls._res_data_path, namespaces=cls._NAMESPACES):
-                print(item)
                 item_data = cast(T, cls._res_data_class.extract(item))
                 data.append(item_data)
         return data

--- a/epplib/responses/base.py
+++ b/epplib/responses/base.py
@@ -358,7 +358,7 @@ class Result(Response, Generic[T]):
             data = None
         else:
             data = []
-            print("IN _extract ")
+            print("IN _extract printing")
             print(cls._NAMESPACES)
             print(cls._res_data_path)
             for item in element.findall(cls._res_data_path, namespaces=cls._NAMESPACES):

--- a/epplib/tests/data/responses/result_info_contact.xml
+++ b/epplib/tests/data/responses/result_info_contact.xml
@@ -33,6 +33,7 @@
       <contact:authInfo>PfLyxPC4</contact:authInfo>
       <contact:disclose flag="1">
          <contact:addr/>
+         <contact:name/>
       </contact:disclose>
       <contact:vat>34567</contact:vat>
       <contact:ident type="passport">45678</contact:ident>

--- a/epplib/tests/test_commands_update.py
+++ b/epplib/tests/test_commands_update.py
@@ -167,7 +167,7 @@ class TestUpdateContact(XMLTestCase):
         "fax": "+420.222123457",
         "email": "john@doe.cz",
         "auth_info": "trnpwd",
-        "disclose": Disclose(True, set((DiscloseField.VOICE,))),
+        "disclose": Disclose(True, set((DiscloseField.VOICE,DiscloseField.NAME))),
         "vat": "1312112029",
         "ident": Ident(IdentType.PASSPORT, "12345"),
         "notify_email": "notify.john@doe.cz",

--- a/epplib/tests/test_models.py
+++ b/epplib/tests/test_models.py
@@ -123,9 +123,9 @@ class TestDisclose(XMLTestCase):
         for flag, result in data:
             with self.subTest(flag=flag):
                 disclose = Disclose(
-                    flag=flag, fields={DiscloseField.VAT, DiscloseField.EMAIL}
+                    flag=flag, fields={DiscloseField.VAT, DiscloseField.EMAIL, DiscloseField.NAME}
                 )
-                expected = EM.disclose(EM.email, EM.vat, flag=result)
+                expected = EM.disclose(EM.email, EM.vat, EM.name, flag=result)
                 self.assertXMLEqual(disclose.get_payload(), expected)
 
     def test_get_payload_order(self):
@@ -139,6 +139,7 @@ class TestDisclose(XMLTestCase):
             EM.vat,
             EM.ident,
             EM.notifyEmail,
+            EM.name,
             flag="1",
         )
         self.assertXMLEqual(disclose.get_payload(), expected)

--- a/epplib/tests/test_responses_info.py
+++ b/epplib/tests/test_responses_info.py
@@ -141,7 +141,7 @@ class TestInfoContactResult(TestCase):
                 voice="+420.12345",
                 fax="+420.23456",
                 email="email@example.com",
-                disclose=Disclose(True, {DiscloseField.ADDR}),
+                disclose=Disclose(True, {DiscloseField.ADDR, DiscloseField.NAME}),
                 vat="34567",
                 ident=Ident(IdentType.PASSPORT, "45678"),
                 notify_email="notify@example.com",

--- a/epplib/tests/tests_ietf/data/infoDomain.xml
+++ b/epplib/tests/tests_ietf/data/infoDomain.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<epp xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:packageToken="urn:google:params:xml:ns:packageToken-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0">
+   <response>
+       <result code="1000">
+           <msg>Command completed successfully</msg>
+       </result>
+       <resData>
+        <domain:infData>
+            <domain:name>test3.gov</domain:name>
+            <domain:roid>DF1340360-GOV</domain:roid>
+            <domain:status s="serverTransferProhibited"/>
+            <domain:status s="inactive"/>
+            <domain:registrant>TuaWnx9hnm84GCSU</domain:registrant>
+            <domain:contact type="security">CONT2</domain:contact>
+            <domain:contact type="tech">CONT3</domain:contact>
+            <domain:clID>gov2023-ote</domain:clID>
+            <domain:crID>gov2023-ote</domain:crID>
+            <domain:crDate>2023-08-15T23:56:36Z</domain:crDate>
+            <domain:upID>gov2023-ote</domain:upID>
+            <domain:upDate>2023-08-17T02:03:19Z</domain:upDate>
+            <domain:exDate>2024-08-15T23:56:36Z</domain:exDate>
+            <domain:authInfo>
+                <domain:pw>2fooBAR123fooBaz</domain:pw>
+            </domain:authInfo>
+        </domain:infData>
+    </resData>
+       <trID>
+           <svTRID>wRRNVhKhQW2m6wsUHbo/lA==-29a</svTRID>
+       </trID>
+   </response>
+
+</epp>

--- a/epplib/tests/tests_ietf/data/infoDomainNoContact.xml
+++ b/epplib/tests/tests_ietf/data/infoDomainNoContact.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<epp xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:packageToken="urn:google:params:xml:ns:packageToken-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0">
+   <response>
+       <result code="1000">
+           <msg>Command completed successfully</msg>
+       </result>
+       <resData>
+        <domain:infData>
+            <domain:name>test3.gov</domain:name>
+            <domain:roid>DF1340360-GOV</domain:roid>
+            <domain:status s="serverTransferProhibited"/>
+            <domain:status s="inactive"/>
+            <domain:registrant>TuaWnx9hnm84GCSU</domain:registrant>
+            <domain:clID>gov2023-ote</domain:clID>
+            <domain:crID>gov2023-ote</domain:crID>
+            <domain:crDate>2023-08-15T23:56:36Z</domain:crDate>
+            <domain:upID>gov2023-ote</domain:upID>
+            <domain:upDate>2023-08-17T02:03:19Z</domain:upDate>
+            <domain:exDate>2024-08-15T23:56:36Z</domain:exDate>
+            <domain:authInfo>
+                <domain:pw>2fooBAR123fooBaz</domain:pw>
+            </domain:authInfo>
+        </domain:infData>
+    </resData>
+       <trID>
+           <svTRID>wRRNVhKhQW2m6wsUHbo/lA==-29a</svTRID>
+       </trID>
+   </response>
+
+</epp>

--- a/epplib/tests/tests_ietf/data/schemas/domain-1.0.xsd
+++ b/epplib/tests/tests_ietf/data/schemas/domain-1.0.xsd
@@ -107,6 +107,7 @@ structure defined in the host mapping.
       <enumeration value="admin" />
       <enumeration value="billing" />
       <enumeration value="tech" />
+      <enumeration value="security" />
     </restriction>
   </simpleType>
 

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -55,16 +55,16 @@ class TestInfoDomainResult(TestCase):
         ]
         text_to_check = "DomainContact(contact='CONT2', type='security')"
 
-        # The right code is returned...
+        # The right code is returned
         self.assertEqual(result.code, 1000)
 
-        # Both objects are the same...        
+        # Both objects are the same       
         self.assertEqual(result.res_data, expected)
 
-        # Both objects have the same contacts...
+        # Both objects have the same contacts
         self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
 
-        # Manually checks for contacts on the returned object (Tests for optional vars)...
+        # Manually checks for contacts on the returned object (Tests for optional vars)
         self.assertIn(text_to_check, str(result.res_data[0]))
 
         text_to_check = "DomainContact(contact='CONT3', type='tech')"
@@ -95,15 +95,15 @@ class TestInfoDomainResult(TestCase):
         ]
         text_to_check = "contacts=[]"
 
-        # The right code is returned...
+        # The right code is returned
         self.assertEqual(result.code, 1000)
 
-        # Both objects are the same...        
+        # Both objects are the same        
         self.assertEqual(result.res_data, expected)
 
-        # Both objects have the same contacts...
+        # Both objects have the same contacts
         self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
 
-        # Manually checks for contacts on the returned object (Tests for optional vars)...
+        # Manually checks for contacts on the returned object (Tests for optional vars)
         self.assertIn(text_to_check, str(result.res_data[0]))
 

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -72,6 +72,7 @@ class TestInfoDomainResult(TestCase):
 
     def test_parse_minimal_no_contact(self):
         location= Path(__file__).parent / "data" / "infoDomainNoContact.xml"
+        text_to_check = "contacts=[]"
         xml = (location).read_bytes()
         result = InfoDomainResult.parse(xml, SCHEMA)
         expected = [
@@ -93,7 +94,6 @@ class TestInfoDomainResult(TestCase):
                 auth_info=DomainAuthInfo(pw="2fooBAR123fooBaz")
             )
         ]
-        text_to_check = "contacts=[]"
 
         # The right code is returned
         self.assertEqual(result.code, 1000)

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -28,7 +28,7 @@ from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
     }
 )
 class TestInfoDomainResult(TestCase):
-    maxDiff = None
+    
     def test_parse_minimal(self):
         location= Path(__file__).parent / "data" / "infoDomain.xml"
         print(location)
@@ -60,8 +60,11 @@ class TestInfoDomainResult(TestCase):
         print(result.res_data)
         print("\n\n\n")
         print(f"expected: {expected[0].contacts}")
-        print(f"result: {result.res_data[0].contacts}")        
+        print(f"result: {result.res_data[0].contacts}")
+        # Both objects are the same        
         self.assertEqual(result.res_data, expected)
+        # Both objects have the same contacts
+        self.assertEqual(expected[0].contacts, result.res_data[0].contacts)
 
     # def test_parse_full(self):
     #     xml = (path(__file__).parent  / "responses/result_info_domain.xml").read_bytes()

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -61,10 +61,54 @@ class TestInfoDomainResult(TestCase):
         print("\n\n\n")
         print(f"expected: {expected[0].contacts}")
         print(f"result: {result.res_data[0].contacts}")
-        # Both objects are the same        
+        # Both objects are the same...        
         self.assertEqual(result.res_data, expected)
-        # Both objects have the same contacts
-        self.assertEqual(expected[0].contacts, result.res_data[0].contacts)
+        # Both objects have the same contacts...
+        self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
+        # Manually checks for contacts on the returned object (Tests for optional vars)...
+        text_to_check = "DomainContact(contact='CONT2', type='security')"
+        self.assertIn(text_to_check, str(result.res_data[0]))
+        text_to_check = "DomainContact(contact='CONT3', type='tech')"
+        self.assertIn(text_to_check, str(result.res_data[0]))
+
+    def test_parse_minimal_no_contact(self):
+        location= Path(__file__).parent / "data" / "infoDomainNoContact.xml"
+        print(location)
+        xml = (location).read_bytes()
+        print(xml)
+        result = InfoDomainResult.parse(xml, SCHEMA)
+        expected = [
+            InfoDomainResultData(
+                name="test3.gov",
+                roid="DF1340360-GOV",
+                statuses=[Status("serverTransferProhibited", None, None),Status("inactive", None, None)],
+                cl_id="gov2023-ote",
+                registrant="TuaWnx9hnm84GCSU",
+                admins=[],
+                nsset=None,
+                keyset=None,
+                cr_id="gov2023-ote",
+                cr_date=datetime(2023, 8, 15, 23, 56, 36, tzinfo=tzutc()),
+                up_id="gov2023-ote",
+                up_date=datetime(2023, 8, 17, 2, 3, 19, tzinfo=tzutc()),
+                ex_date=date(2024, 8, 15),
+                tr_date=None,
+                auth_info=DomainAuthInfo(pw="2fooBAR123fooBaz")
+            )
+        ]
+        self.assertEqual(result.code, 1000)
+        print("result.res_data")
+        print(result.res_data)
+        print("\n\n\n")
+        print(f"expected: {expected[0].contacts}")
+        print(f"result: {result.res_data[0].contacts}")
+        # Both objects are the same...        
+        self.assertEqual(result.res_data, expected)
+        # Both objects have the same contacts...
+        self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
+        # Manually checks for contacts on the returned object (Tests for optional vars)...
+        text_to_check = "contacts=[]"
+        self.assertIn(text_to_check, str(result.res_data[0]))
 
     # def test_parse_full(self):
     #     xml = (path(__file__).parent  / "responses/result_info_domain.xml").read_bytes()

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -31,9 +31,7 @@ class TestInfoDomainResult(TestCase):
     
     def test_parse_minimal(self):
         location= Path(__file__).parent / "data" / "infoDomain.xml"
-        print(location)
         xml = (location).read_bytes()
-        print(xml)
         result = InfoDomainResult.parse(xml, SCHEMA)
         expected = [
             InfoDomainResultData(
@@ -55,28 +53,26 @@ class TestInfoDomainResult(TestCase):
                 auth_info=DomainAuthInfo(pw="2fooBAR123fooBaz")
             )
         ]
+        text_to_check = "DomainContact(contact='CONT2', type='security')"
+
+        # The right code is returned...
         self.assertEqual(result.code, 1000)
-        print("result.res_data")
-        print(result.res_data)
-        print("\n\n\n")
-        print(f"expected: {expected[0].contacts}")
-        print(f"result: {result.res_data[0].contacts}")
-        print("\n\n\n")
+
         # Both objects are the same...        
         self.assertEqual(result.res_data, expected)
+
         # Both objects have the same contacts...
         self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
+
         # Manually checks for contacts on the returned object (Tests for optional vars)...
-        text_to_check = "DomainContact(contact='CONT2', type='security')"
         self.assertIn(text_to_check, str(result.res_data[0]))
+
         text_to_check = "DomainContact(contact='CONT3', type='tech')"
         self.assertIn(text_to_check, str(result.res_data[0]))
 
     def test_parse_minimal_no_contact(self):
         location= Path(__file__).parent / "data" / "infoDomainNoContact.xml"
-        print(location)
         xml = (location).read_bytes()
-        print(xml)
         result = InfoDomainResult.parse(xml, SCHEMA)
         expected = [
             InfoDomainResultData(
@@ -97,54 +93,17 @@ class TestInfoDomainResult(TestCase):
                 auth_info=DomainAuthInfo(pw="2fooBAR123fooBaz")
             )
         ]
+        text_to_check = "contacts=[]"
+
+        # The right code is returned...
         self.assertEqual(result.code, 1000)
-        print("result.res_data")
-        print(result.res_data)
-        print("\n\n\n")
-        print(f"expected: {expected[0].contacts}")
-        print(f"result: {result.res_data[0].contacts}")
+
         # Both objects are the same...        
         self.assertEqual(result.res_data, expected)
+
         # Both objects have the same contacts...
         self.assertEqual(result.res_data[0].contacts, expected[0].contacts)
+
         # Manually checks for contacts on the returned object (Tests for optional vars)...
-        text_to_check = "contacts=[]"
         self.assertIn(text_to_check, str(result.res_data[0]))
-
-    # def test_parse_full(self):
-    #     xml = (path(__file__).parent  / "responses/result_info_domain.xml").read_bytes()
-    #     result = InfoDomainResult.parse(xml, SCHEMA)
-    #     expected = [
-    #         InfoDomainResultData(
-    #             name="mydomain.cz",
-    #             roid="D0009907597-CZ",
-    #             statuses=[Status("ok", "Object is without restrictions", "en")],
-    #             cl_id="REG-MYREG",
-    #             registrant="CID-MYOWN",
-    #             admins=["CID-ADMIN2", "CID-ADMIN3"],
-    #             nsset="NID-MYNSSET",
-    #             keyset="KID-MYKEYSET",
-    #             cr_id="REG-MYREG",
-    #             cr_date=datetime(
-    #                 2017, 7, 11, 13, 28, 48, tzinfo=timezone(timedelta(hours=2))
-    #             ),
-    #             up_id="REG-MYREG",
-    #             up_date=datetime(
-    #                 2017, 7, 18, 10, 46, 19, tzinfo=timezone(timedelta(hours=2))
-    #             ),
-    #             ex_date=date(2020, 7, 11),
-    #             tr_date=datetime(
-    #                 2017, 7, 19, 10, 46, 19, tzinfo=timezone(timedelta(hours=2))
-    #             ),
-    #             auth_info="rvBcaTVq",
-    #         )
-    #     ]
-
-    #     self.assertEqual(result.code, 1000)
-    #     self.assertEqual(result.res_data, expected)
-
-    # def test_parse_error(self):
-    #     xml = (BASE_DATA_PATH / "responses/result_error.xml").read_bytes()
-    #     result = InfoDomainResult.parse(xml, SCHEMA)
-    #     self.assertEqual(result.code, 2002)
 

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -61,6 +61,7 @@ class TestInfoDomainResult(TestCase):
         print("\n\n\n")
         print(f"expected: {expected[0].contacts}")
         print(f"result: {result.res_data[0].contacts}")
+        print("\n\n\n")
         # Both objects are the same...        
         self.assertEqual(result.res_data, expected)
         # Both objects have the same contacts...

--- a/epplib/tests/tests_ietf/test_responses.py
+++ b/epplib/tests/tests_ietf/test_responses.py
@@ -1,0 +1,84 @@
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from unittest import TestCase
+
+from epplib.models import Status
+from epplib.models.common import DomainAuthInfo
+from epplib.models.info import InfoDomainResultData
+from epplib.responses import InfoDomainResult
+
+from unittest.mock import patch 
+from epplib.tests.tests_ietf.constants import NAMESPACE, SCHEMA_LOCATION, SCHEMA
+@patch("epplib.commands.info.NAMESPACE", NAMESPACE)
+@patch("epplib.commands.info.SCHEMA_LOCATION", SCHEMA_LOCATION)
+@patch("epplib.models.common.DomainAuthInfo.namespace", NAMESPACE.NIC_DOMAIN)
+class TestInfoDomainResult(TestCase):
+    def test_parse_minimal(self):
+        location= Path(__file__).parent / "data" / "infoDomain.xml"
+        print(location)
+        xml = (location).read_bytes()
+        print(xml)
+        result = InfoDomainResult.parse(xml, SCHEMA)
+        expected = [
+            InfoDomainResultData(
+                name="test3.gov",
+                roid="DF1340360-GOV",
+                statuses=[Status("serverTransferProhibited", "", None),Status("inactive", "", None)],
+                cl_id="gov2023-ote",
+                contacts=["CONT2","CONT3"],
+                registrant="TuaWnx9hnm84GCSU",
+                admins=[],
+                nsset=None,
+                keyset=None,
+                cr_id="gov2023-ote",
+                cr_date="2023-08-15T23:56:36Z",
+                up_id=None,
+                up_date="2023-08-17T02:03:19Z",
+                ex_date="2024-08-15T23:56:36Z",
+                tr_date=None,
+                auth_info=DomainAuthInfo(pw="2fooBAR123fooBaz"),
+            )
+        ]
+        print(result)
+        self.assertEqual(result.code, 1000)
+        print("result.res_data")
+        print(result.res_data)        
+        self.assertEqual(result.res_data, expected)
+
+    # def test_parse_full(self):
+    #     xml = (path(__file__).parent  / "responses/result_info_domain.xml").read_bytes()
+    #     result = InfoDomainResult.parse(xml, SCHEMA)
+    #     expected = [
+    #         InfoDomainResultData(
+    #             name="mydomain.cz",
+    #             roid="D0009907597-CZ",
+    #             statuses=[Status("ok", "Object is without restrictions", "en")],
+    #             cl_id="REG-MYREG",
+    #             registrant="CID-MYOWN",
+    #             admins=["CID-ADMIN2", "CID-ADMIN3"],
+    #             nsset="NID-MYNSSET",
+    #             keyset="KID-MYKEYSET",
+    #             cr_id="REG-MYREG",
+    #             cr_date=datetime(
+    #                 2017, 7, 11, 13, 28, 48, tzinfo=timezone(timedelta(hours=2))
+    #             ),
+    #             up_id="REG-MYREG",
+    #             up_date=datetime(
+    #                 2017, 7, 18, 10, 46, 19, tzinfo=timezone(timedelta(hours=2))
+    #             ),
+    #             ex_date=date(2020, 7, 11),
+    #             tr_date=datetime(
+    #                 2017, 7, 19, 10, 46, 19, tzinfo=timezone(timedelta(hours=2))
+    #             ),
+    #             auth_info="rvBcaTVq",
+    #         )
+    #     ]
+
+    #     self.assertEqual(result.code, 1000)
+    #     self.assertEqual(result.res_data, expected)
+
+    # def test_parse_error(self):
+    #     xml = (BASE_DATA_PATH / "responses/result_error.xml").read_bytes()
+    #     result = InfoDomainResult.parse(xml, SCHEMA)
+    #     self.assertEqual(result.code, 2002)
+


### PR DESCRIPTION
## 🗣 Description ##
Fixes the InfoDomainResponse return by changing `contacts: InitVar[Optional[List[str]]] = None` to `contacts: Optional[List[str]] = field(default=None, repr=True)` on both hosts and contacts. Works the same, except now it populates as a value when printing.

## 💭 Motivation and context ##
Directly solves [#809](https://github.com/cisagov/getgov/issues/809). In essence, we had incorrectly assumed that "contacts" never existed on the InfoDomainResponse object (i.e. was never returned), but it turns out that this was a consequence of its model structure, rather than a bug. As a result, contacts would be returned if called directly: print(response.res_data[0].contacts)
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Test using python3 -m unittest ./epplib/tests/tests_ietf/test_responses.py
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
